### PR TITLE
FR-1133 get back up to 100 percent test coverage

### DIFF
--- a/cmd/ubuntu-image/main_test.go
+++ b/cmd/ubuntu-image/main_test.go
@@ -105,8 +105,10 @@ func TestExitCode(t *testing.T) {
 		flags    []string
 		expected int
 	}{
-		{"exit 0", []string{"snap", "model_assertion.yml"}, 0},
+		{"snap exit 0", []string{"snap", "model_assertion.yml"}, 0},
+		{"classic exit 0", []string{"classic", "gadget_tree.yml"}, 0},
 		{"exit 1", []string{"--help-me"}, 1},
+		{"help exit 0", []string{"--help"}, 0},
 	}
 	for _, tc := range testCases {
 		t.Run("test "+tc.name, func(t *testing.T) {


### PR DESCRIPTION
We accidentally slipped below 100% test coverage when adding the logic to "exit 0" with ErrHelp. This gets us back up to 100.