### PR TITLE
Export StateMachine fields for partial runs

### DIFF
--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -135,11 +135,11 @@ func (stateMachine *StateMachine) generateDiskInfo() error {
 // on a 100MiB filesystem, ext4 takes a little over 7MiB for the
 // metadata. Use 8MB as a minimum padding here
 func (stateMachine *StateMachine) calculateRootfsSize() error {
-	RootfsSize, err := helper.Du(stateMachine.tempDirs.rootfs)
+	rootfsSize, err := helper.Du(stateMachine.tempDirs.rootfs)
 	if err != nil {
 		return fmt.Errorf("Error getting rootfs size: %s", err.Error())
 	}
-	var rootfsQuantity quantity.Size = RootfsSize
+	var rootfsQuantity quantity.Size = rootfsSize
 	rootfsPadding := 8 * quantity.SizeMiB
 
 	// fudge factor for incidentals

--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -93,7 +93,7 @@ func (stateMachine *StateMachine) loadGadgetYaml() error {
 
 // Run hooks specified by --hooks-directory after populating rootfs contents
 func (stateMachine *StateMachine) populateRootfsContentsHooks() error {
-	if stateMachine.isSeeded {
+	if stateMachine.IsSeeded {
 		if stateMachine.commonFlags.Debug {
 			fmt.Println("Building from a seeded gadget - " +
 				"skipping the post-populate-rootfs hook execution: unsupported")
@@ -135,18 +135,18 @@ func (stateMachine *StateMachine) generateDiskInfo() error {
 // on a 100MiB filesystem, ext4 takes a little over 7MiB for the
 // metadata. Use 8MB as a minimum padding here
 func (stateMachine *StateMachine) calculateRootfsSize() error {
-	rootfsSize, err := helper.Du(stateMachine.tempDirs.rootfs)
+	RootfsSize, err := helper.Du(stateMachine.tempDirs.rootfs)
 	if err != nil {
 		return fmt.Errorf("Error getting rootfs size: %s", err.Error())
 	}
-	var rootfsQuantity quantity.Size = rootfsSize
+	var rootfsQuantity quantity.Size = RootfsSize
 	rootfsPadding := 8 * quantity.SizeMiB
 
 	// fudge factor for incidentals
 	rootfsQuantity = quantity.Size(math.Ceil(float64(rootfsQuantity) * 1.5))
 	rootfsQuantity += rootfsPadding
 
-	stateMachine.rootfsSize = rootfsQuantity
+	stateMachine.RootfsSize = rootfsQuantity
 
 	// we have already saved the rootfs size in the state machine struct, but we
 	// should also set it in the gadget.Structure that represents the rootfs
@@ -201,7 +201,7 @@ func (stateMachine *StateMachine) populateBootfsContents() error {
 		// /EFI/ubuntu.  This is because we are using a SecureBoot
 		// signed bootloader image which has this path embedded, so
 		// we need to install our files to there.
-		if !stateMachine.isSeeded &&
+		if !stateMachine.IsSeeded &&
 			(laidOutStructure.Role == gadget.SystemBoot ||
 				laidOutStructure.Label == gadget.SystemBoot) {
 			if err := stateMachine.handleSecureBoot(systemVolume, targetDir); err != nil {
@@ -245,7 +245,7 @@ func (stateMachine *StateMachine) populatePreparePartitions() error {
 			}
 			farthestOffset = maxOffset(farthestOffset,
 				quantity.Offset(structure.Size)+getStructureOffset(structure))
-			if shouldSkipStructure(structure, stateMachine.isSeeded) {
+			if shouldSkipStructure(structure, stateMachine.IsSeeded) {
 				continue
 			}
 
@@ -293,7 +293,7 @@ func (stateMachine *StateMachine) makeDisk() error {
 		sectorSize := uint64(diskImg.LogicalBlocksize)
 
 		// set up the partitions on the device
-		partitionTable := createPartitionTable(volumeName, volume, sectorSize, stateMachine.isSeeded)
+		partitionTable := createPartitionTable(volumeName, volume, sectorSize, stateMachine.IsSeeded)
 
 		// Write the partition table to disk
 		if err := diskImg.Partition(*partitionTable); err != nil {

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -218,7 +218,7 @@ func TestPopulateRootfsContentsHooks(t *testing.T) {
 				filepath.Join("testdata", "good_hooksd"),
 				filepath.Join("testdata", "good_hookscript"),
 			}
-			stateMachine.isSeeded = tc.isSeeded
+			stateMachine.IsSeeded = tc.isSeeded
 
 			// need workdir set up for this
 			err := stateMachine.makeTemporaryDirectories()
@@ -258,7 +258,7 @@ func TestFailedPopulateRootfsContentsHooks(t *testing.T) {
 			var stateMachine StateMachine
 			stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 			stateMachine.commonFlags.HooksDirectories = tc.hooksDirs
-			stateMachine.isSeeded = false
+			stateMachine.IsSeeded = false
 
 			// need workdir set up for this
 			err := stateMachine.makeTemporaryDirectories()
@@ -356,12 +356,12 @@ func TestCalculateRootfsSize(t *testing.T) {
 		// rootfs size will be slightly different in different environments
 		correctSizeLower, _ := quantity.ParseSize("8M")
 		correctSizeUpper := correctSizeLower + 100000 // 0.1 MB range
-		if stateMachine.rootfsSize > correctSizeUpper ||
-			stateMachine.rootfsSize < correctSizeLower {
-			t.Errorf("expected rootfsSize between %s and %s, got %s",
+		if stateMachine.RootfsSize > correctSizeUpper ||
+			stateMachine.RootfsSize < correctSizeLower {
+			t.Errorf("expected RootfsSize between %s and %s, got %s",
 				correctSizeLower.IECString(),
 				correctSizeUpper.IECString(),
-				stateMachine.rootfsSize.IECString())
+				stateMachine.RootfsSize.IECString())
 		}
 
 		os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
@@ -485,7 +485,7 @@ func TestFailedPopulateBootfsContents(t *testing.T) {
 		// ensure unpack exists
 		err = stateMachine.loadGadgetYaml()
 		asserter.AssertErrNil(err, true)
-		stateMachine.isSeeded = false
+		stateMachine.IsSeeded = false
 		// now ensure grub dir exists
 		os.MkdirAll(filepath.Join(stateMachine.tempDirs.unpack,
 			"image", "boot", "grub"), 0755)

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -358,7 +358,7 @@ func TestCalculateRootfsSize(t *testing.T) {
 		correctSizeUpper := correctSizeLower + 100000 // 0.1 MB range
 		if stateMachine.RootfsSize > correctSizeUpper ||
 			stateMachine.RootfsSize < correctSizeLower {
-			t.Errorf("expected RootfsSize between %s and %s, got %s",
+			t.Errorf("expected rootfs size between %s and %s, got %s",
 				correctSizeLower.IECString(),
 				correctSizeUpper.IECString(),
 				stateMachine.RootfsSize.IECString())

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -188,13 +188,13 @@ func (stateMachine *StateMachine) copyStructureContent(volume *gadget.Volume,
 		if structure.Role == gadget.SystemData || structure.Role == gadget.SystemSeed {
 			// system-data and system-seed structures are not required to have
 			// an explicit size set in the yaml file
-			if structure.Size < stateMachine.rootfsSize {
+			if structure.Size < stateMachine.RootfsSize {
 				fmt.Printf("WARNING: rootfs structure size %s smaller "+
 					"than actual rootfs contents %s\n",
 					structure.Size.IECString(),
-					stateMachine.rootfsSize.IECString())
-				blockSize = stateMachine.rootfsSize
-				structure.Size = stateMachine.rootfsSize
+					stateMachine.RootfsSize.IECString())
+				blockSize = stateMachine.RootfsSize
+				structure.Size = stateMachine.RootfsSize
 				volume.Structure[structureNumber] = structure
 			} else {
 				blockSize = structure.Size
@@ -204,7 +204,7 @@ func (stateMachine *StateMachine) copyStructureContent(volume *gadget.Volume,
 		}
 		if structure.Role == gadget.SystemData {
 			os.Create(partImg)
-			os.Truncate(partImg, int64(stateMachine.rootfsSize))
+			os.Truncate(partImg, int64(stateMachine.RootfsSize))
 		} else {
 			// use mkfs functions from snapd to create the filesystems
 			ddArgs := []string{"if=/dev/zero", "of=" + partImg, "count=0",
@@ -459,7 +459,7 @@ func (stateMachine *StateMachine) calculateImageSize() (int64, error) {
 // copyDataToImage runs dd commands to copy the raw data to the final image with appropriate offsets
 func (stateMachine *StateMachine) copyDataToImage(volumeName string, volume *gadget.Volume, diskImg *disk.Disk) error {
 	for structureNumber, structure := range volume.Structure {
-		if shouldSkipStructure(structure, stateMachine.isSeeded) {
+		if shouldSkipStructure(structure, stateMachine.IsSeeded) {
 			continue
 		}
 		sectorSize := diskImg.LogicalBlocksize

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -497,10 +497,10 @@ func TestWarningRootfsSizeTooSmall(t *testing.T) {
 		// check that the size was correctly updated in the volume
 		for _, structure := range volume.Structure {
 			if structure.Role == gadget.SystemData {
-				if structure.Size != stateMachine.rootfsSize {
+				if structure.Size != stateMachine.RootfsSize {
 					t.Errorf("rootfs structure size %s is not equal to calculated size %s",
 						structure.Size.IECString(),
-						stateMachine.rootfsSize.IECString())
+						stateMachine.RootfsSize.IECString())
 				}
 			}
 		}

--- a/internal/statemachine/snap_states.go
+++ b/internal/statemachine/snap_states.go
@@ -48,7 +48,7 @@ func (stateMachine *StateMachine) prepareImage() error {
 // populateSnapRootfsContents uses a NewMountedFileSystemWriter to populate the rootfs
 func (stateMachine *StateMachine) populateSnapRootfsContents() error {
 	var src, dst string
-	if stateMachine.isSeeded {
+	if stateMachine.IsSeeded {
 		// For now, since we only create the system-seed partition for
 		// uc20 images, we hard-code to use this path for the rootfs
 		// seed population.  In the future we might want to consider
@@ -71,7 +71,7 @@ func (stateMachine *StateMachine) populateSnapRootfsContents() error {
 		return fmt.Errorf("Error reading unpack dir: %s", err.Error())
 	}
 	for _, srcFile := range files {
-		if !stateMachine.isSeeded && srcFile.Name() == "boot" {
+		if !stateMachine.IsSeeded && srcFile.Name() == "boot" {
 			continue
 		}
 		srcFileName := filepath.Join(src, srcFile.Name())
@@ -100,7 +100,7 @@ func (stateMachine *StateMachine) generateSnapManifest() error {
 
 	// seed.manifest
 	outputPath = filepath.Join(stateMachine.commonFlags.OutputDir, "seed.manifest")
-	if stateMachine.isSeeded {
+	if stateMachine.IsSeeded {
 		snapsDir = filepath.Join(stateMachine.tempDirs.rootfs, "snaps")
 	} else {
 		snapsDir = filepath.Join(stateMachine.tempDirs.rootfs, "system-data", "var", "lib", "snapd", "seed", "snaps")

--- a/internal/statemachine/snap_test.go
+++ b/internal/statemachine/snap_test.go
@@ -227,7 +227,7 @@ func TestGenerateSnapManifest(t *testing.T) {
 			stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 			stateMachine.stateMachineFlags.WorkDir = workDir
 			stateMachine.tempDirs.rootfs = filepath.Join(workDir, "rootfs")
-			stateMachine.isSeeded = tc.seeded
+			stateMachine.IsSeeded = tc.seeded
 			stateMachine.commonFlags.OutputDir = filepath.Join(workDir, "output")
 			osMkdirAll(stateMachine.commonFlags.OutputDir, 0755)
 
@@ -360,7 +360,7 @@ func TestFailedGenerateSnapManifest(t *testing.T) {
 		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 		stateMachine.stateMachineFlags.WorkDir = "/dummy/path"
 		stateMachine.tempDirs.rootfs = "/dummy/path"
-		stateMachine.isSeeded = false
+		stateMachine.IsSeeded = false
 		stateMachine.commonFlags.OutputDir = "/dummy/path"
 
 		err := stateMachine.generateSnapManifest()

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -69,8 +69,8 @@ type StateMachine struct {
 	CurrentStep  string // tracks the current progress of the state machine
 	StepsTaken   int    // counts the number of steps taken
 	YamlFilePath string // the location for the yaml file
-	isSeeded     bool   // core 20 images are seeded
-	rootfsSize   quantity.Size
+	IsSeeded     bool   // core 20 images are seeded
+	RootfsSize   quantity.Size
 	tempDirs     temporaryDirectories
 
 	// The flags that were passed in on the command line
@@ -87,7 +87,7 @@ type StateMachine struct {
 
 	// image sizes for parsing the --image-size flags
 	ImageSizes  map[string]quantity.Size
-	volumeOrder []string
+	VolumeOrder []string
 }
 
 // SetCommonOpts stores the common options for all image types in the struct
@@ -136,8 +136,8 @@ func (stateMachine *StateMachine) parseImageSizes() error {
 			volumeNumber, err := strconv.Atoi(splitSize[0])
 			if err == nil {
 				// argument passed was numeric.
-				if volumeNumber < len(stateMachine.volumeOrder) {
-					stateName := stateMachine.volumeOrder[volumeNumber]
+				if volumeNumber < len(stateMachine.VolumeOrder) {
+					stateName := stateMachine.VolumeOrder[volumeNumber]
 					stateMachine.ImageSizes[stateName] = parsedSize
 				} else {
 					return fmt.Errorf("Volume index %d is out of range", volumeNumber)
@@ -189,7 +189,7 @@ func (stateMachine *StateMachine) saveVolumeOrder(gadgetYamlContents string) {
 		sortedVolumes = append(sortedVolumes, volume.VolumeName)
 	}
 
-	stateMachine.volumeOrder = sortedVolumes
+	stateMachine.VolumeOrder = sortedVolumes
 }
 
 // postProcessGadgetYaml adds the rootfs to the partitions list if needed
@@ -213,7 +213,7 @@ func (stateMachine *StateMachine) postProcessGadgetYaml() error {
 			} else if structure.Role == gadget.SystemData {
 				rootfsSeen = true
 			} else if structure.Role == gadget.SystemSeed {
-				stateMachine.isSeeded = true
+				stateMachine.IsSeeded = true
 				if structure.Label == "" {
 					structure.Label = "ubuntu-seed"
 					volume.Structure[ii] = structure
@@ -291,6 +291,9 @@ func (stateMachine *StateMachine) readMetadata() error {
 		stateMachine.GadgetInfo = partialStateMachine.GadgetInfo
 		stateMachine.YamlFilePath = partialStateMachine.YamlFilePath
 		stateMachine.ImageSizes = partialStateMachine.ImageSizes
+		stateMachine.RootfsSize = partialStateMachine.RootfsSize
+		stateMachine.IsSeeded = partialStateMachine.IsSeeded
+		stateMachine.VolumeOrder = partialStateMachine.VolumeOrder
 		stateMachine.tempDirs.rootfs = filepath.Join(stateMachine.stateMachineFlags.WorkDir, "root")
 		stateMachine.tempDirs.unpack = filepath.Join(stateMachine.stateMachineFlags.WorkDir, "unpack")
 		stateMachine.tempDirs.volumes = filepath.Join(stateMachine.stateMachineFlags.WorkDir, "volumes")


### PR DESCRIPTION
While manually testing I found a couple of edge cases where --until and --thru flags would still build images, but their partition tables were misaligned. I've addressed this by exporting more fields (so they can be written to disk with encoding.gob) and reading them back in during readMetadata().