### PR TITLE
Add conflicts for python3-ubuntu-image

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,15 @@
 ubuntu-image (2.0+21.10ubuntu1) UNRELEASED; urgency=medium
 
+  [ William 'jawn-smith' Wilson ]
   * Re-write ubuntu-image in Go to improve integration with snapd
     - Remove -o / --output option that has been deprecated for years
     - The command line option --hooks-directory must now be specified
       once per hooks directory, rather than a comma separated list.
+
+  [ Łukasz 'sil2100' Zemczak ]
+  * debian/control: as we're replacing the python ubuntu-image version,
+    force removal of the no-longer used python3-ubuntu-image via a Conflicts
+    stanza.
 
  -- William 'jawn-smith' Wilson <william.wilson@canonical.com>  Mon, 26 Apr 2021 15:33:22 -0500
 

--- a/debian/control
+++ b/debian/control
@@ -24,5 +24,6 @@ Depends: ${shlibs:Depends},
          livecd-rootfs,
          mtools,
          snapd,
+Conflicts: python3-ubuntu-image
 Description: toolkit for building Ubuntu images.
  This package contains the ubuntu-image program.


### PR DESCRIPTION
I would say this is still up for discussion, but since we overwrite the existing ubuntu-image with the golang version, as things are right now users might still have python3-ubuntu-image lying around (possibly marked for removal). So normally I guess `autoremove` would just purge them when needed, but some people might have it around if not running the command - and then still use it and wonder why it's outdated.

So maybe a conflicts here makes sense? What do you think? Maybe it's not needed?