### PR TITLE
Add logic to ensure image size is a multiple of block size

### DIFF
--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -290,7 +290,7 @@ func (stateMachine *StateMachine) makeDisk() error {
 		}
 
 		// make sure the disk image size is a multiple of its block size
-		imgSize = int64(math.Ceil(float64(imgSize) / float64(diskImg.LogicalBlocksize))) *
+		imgSize = int64(math.Ceil(float64(imgSize)/float64(diskImg.LogicalBlocksize))) *
 			int64(diskImg.LogicalBlocksize)
 		if err := osTruncate(diskImg.File.Name(), imgSize); err != nil {
 			return fmt.Errorf("Error resizing disk image to a multiple of its block size: %s",

--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -289,6 +289,14 @@ func (stateMachine *StateMachine) makeDisk() error {
 			return fmt.Errorf("Error creating disk image: %s", err.Error())
 		}
 
+		// make sure the disk image size is a multiple of its block size
+		imgSize = int64(math.Ceil(float64(imgSize) / float64(diskImg.LogicalBlocksize))) *
+			int64(diskImg.LogicalBlocksize)
+		if err := osTruncate(diskImg.File.Name(), imgSize); err != nil {
+			return fmt.Errorf("Error resizing disk image to a multiple of its block size: %s",
+				err.Error())
+		}
+
 		// snapd always populates Schema, so it cannot be empty. Use the blocksize of the created disk
 		sectorSize := uint64(diskImg.LogicalBlocksize)
 

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -759,6 +759,16 @@ func TestFailedMakeDisk(t *testing.T) {
 		diskfsCreate = diskfs.Create
 		os.Remove(filepath.Join(outDir, "pc.img")) // clean up for the next test run
 
+		// mock os.Truncate
+		osTruncate = mockTruncate
+		defer func() {
+			osTruncate = os.Truncate
+		}()
+		err = stateMachine.makeDisk()
+		asserter.AssertErrContains(err, "Error resizing disk image")
+		osTruncate = os.Truncate
+		os.Remove(filepath.Join(outDir, "pc.img")) // clean up for the next test run
+
 		// mock diskfs.Create to create a read only disk
 		diskfsCreate = readOnlyDiskfsCreate
 		defer func() {

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -702,7 +702,7 @@ func TestMakeDiskPartitionSchemes(t *testing.T) {
 			diskImg, err := diskfs.Open(imgFile)
 			defer diskImg.File.Close()
 			asserter.AssertErrNil(err, true)
-			if diskImg.Size % diskImg.LogicalBlocksize != 0 {
+			if diskImg.Size%diskImg.LogicalBlocksize != 0 {
 				t.Errorf("Disk image size %d is not an multiple of the block size: %d",
 					diskImg.Size, diskImg.LogicalBlocksize)
 			}

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -697,6 +697,15 @@ func TestMakeDiskPartitionSchemes(t *testing.T) {
 				t.Errorf("File %s should have partition table %s, instead got \"%s\"",
 					imgFile, tc.tableType, string(dumpe2fsBytes))
 			}
+
+			// ensure the resulting image file is a multiple of the block size
+			diskImg, err := diskfs.Open(imgFile)
+			defer diskImg.File.Close()
+			asserter.AssertErrNil(err, true)
+			if diskImg.Size % diskImg.LogicalBlocksize != 0 {
+				t.Errorf("Disk image size %d is not an multiple of the block size: %d",
+					diskImg.Size, diskImg.LogicalBlocksize)
+			}
 		})
 	}
 }

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -35,6 +35,7 @@ var osOpenFile = os.OpenFile
 var osRemoveAll = os.RemoveAll
 var osRename = os.Rename
 var osCreate = os.Create
+var osTruncate = os.Truncate
 var osutilCopyFile = osutil.CopyFile
 var osutilCopySpecialFile = osutil.CopySpecialFile
 var execCommand = exec.Command

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -87,6 +87,9 @@ func mockRemoveAll(string) error {
 func mockRename(string, string) error {
 	return fmt.Errorf("Test error")
 }
+func mockTruncate(string, int64) error {
+	return fmt.Errorf("Test error")
+}
 func mockCreate(string) (*os.File, error) {
 	return nil, fmt.Errorf("Test error")
 }


### PR DESCRIPTION
Currently the image can be created with a size that isn't a multiple of the block size. The resulting images still boot fine, but applications like parted and gnome-disks can throw warnings as a result.

We had a bit of a chicken and egg situation where we have to create the disk image in order to determine the block size, but that was solved by using os.Truncate to resize the image after creating it.