### PR TITLE
Cleanup old images

### DIFF
--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -290,7 +290,7 @@ func (stateMachine *StateMachine) makeDisk() error {
 		}
 
 		// make sure the disk image size is a multiple of its block size
-		imgSize = int64(math.Ceil(float64(imgSize) / float64(diskImg.LogicalBlocksize))) *
+		imgSize = int64(math.Ceil(float64(imgSize)/float64(diskImg.LogicalBlocksize))) *
 			int64(diskImg.LogicalBlocksize)
 		if err := osTruncate(diskImg.File.Name(), imgSize); err != nil {
 			return fmt.Errorf("Error resizing disk image to a multiple of its block size: %s",

--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -284,6 +284,9 @@ func (stateMachine *StateMachine) makeDisk() error {
 		// Create the disk image
 		imgSize, _ := stateMachine.calculateImageSize()
 
+		if err := osRemoveAll(imgName); err != nil {
+			return fmt.Errorf("Error removing old disk image: %s", err.Error())
+		}
 		diskImg, err := diskfsCreate(imgName, imgSize, diskfs.Raw)
 		if err != nil {
 			return fmt.Errorf("Error creating disk image: %s", err.Error())

--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -289,6 +289,14 @@ func (stateMachine *StateMachine) makeDisk() error {
 			return fmt.Errorf("Error creating disk image: %s", err.Error())
 		}
 
+		// make sure the disk image size is a multiple of its block size
+		imgSize = int64(math.Ceil(float64(imgSize) / float64(diskImg.LogicalBlocksize))) *
+			int64(diskImg.LogicalBlocksize)
+		if err := osTruncate(diskImg.File.Name(), imgSize); err != nil {
+			return fmt.Errorf("Error resizing disk image to a multiple of its block size: %s",
+				err.Error())
+		}
+
 		// snapd always populates Schema, so it cannot be empty. Use the blocksize of the created disk
 		sectorSize := uint64(diskImg.LogicalBlocksize)
 

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -758,6 +758,15 @@ func TestFailedMakeDisk(t *testing.T) {
 		asserter.AssertErrContains(err, "Error creating OutputDir")
 		osMkdirAll = os.MkdirAll
 
+		// mock os.RemoveAll
+		osRemoveAll = mockRemoveAll
+		defer func() {
+			osRemoveAll = os.RemoveAll
+		}()
+		err = stateMachine.makeDisk()
+		asserter.AssertErrContains(err, "Error removing old disk image")
+		osRemoveAll = os.RemoveAll
+
 		// mock diskfs.Create
 		diskfsCreate = mockDiskfsCreate
 		defer func() {
@@ -766,7 +775,6 @@ func TestFailedMakeDisk(t *testing.T) {
 		err = stateMachine.makeDisk()
 		asserter.AssertErrContains(err, "Error creating disk image")
 		diskfsCreate = diskfs.Create
-		os.Remove(filepath.Join(outDir, "pc.img")) // clean up for the next test run
 
 		// mock os.Truncate
 		osTruncate = mockTruncate
@@ -776,7 +784,6 @@ func TestFailedMakeDisk(t *testing.T) {
 		err = stateMachine.makeDisk()
 		asserter.AssertErrContains(err, "Error resizing disk image")
 		osTruncate = os.Truncate
-		os.Remove(filepath.Join(outDir, "pc.img")) // clean up for the next test run
 
 		// mock diskfs.Create to create a read only disk
 		diskfsCreate = readOnlyDiskfsCreate
@@ -786,7 +793,6 @@ func TestFailedMakeDisk(t *testing.T) {
 		err = stateMachine.makeDisk()
 		asserter.AssertErrContains(err, "Error partitioning image file")
 		diskfsCreate = diskfs.Create
-		os.Remove(filepath.Join(outDir, "pc.img"))
 
 		// mock os.OpenFile
 		// errors in file.WriteAt()
@@ -797,7 +803,6 @@ func TestFailedMakeDisk(t *testing.T) {
 		err = stateMachine.makeDisk()
 		asserter.AssertErrContains(err, "Error opening disk to write MBR disk identifier")
 		osOpenFile = os.OpenFile
-		os.Remove(filepath.Join(outDir, "pc.img"))
 
 		// mock os.OpenFile to force it to use os.O_APPEND, which causes
 		// errors in file.WriteAt()
@@ -808,7 +813,6 @@ func TestFailedMakeDisk(t *testing.T) {
 		err = stateMachine.makeDisk()
 		asserter.AssertErrContains(err, "Error writing MBR disk identifier")
 		osOpenFile = os.OpenFile
-		os.Remove(filepath.Join(outDir, "pc.img"))
 
 		// mock helper.CopyBlob to simulate a failure in copyDataToImage
 		helperCopyBlob = mockCopyBlob
@@ -818,7 +822,6 @@ func TestFailedMakeDisk(t *testing.T) {
 		err = stateMachine.makeDisk()
 		asserter.AssertErrContains(err, "Error writing disk image")
 		helperCopyBlob = helper.CopyBlob
-		os.Remove(filepath.Join(outDir, "pc.img"))
 
 		// Change to GPT for these next tests
 		stateMachine.YamlFilePath = filepath.Join("testdata", "gadget-gpt.yaml")
@@ -845,7 +848,6 @@ func TestFailedMakeDisk(t *testing.T) {
 		asserter.AssertErrContains(err, "Error opening image file")
 		osOpenFile = os.OpenFile
 		helperCopyBlob = helper.CopyBlob
-		os.Remove(filepath.Join(outDir, "pc.img"))
 
 		helperCopyBlob = mockCopyBlob
 		defer func() {
@@ -855,7 +857,6 @@ func TestFailedMakeDisk(t *testing.T) {
 		stateMachine.commonFlags.OutputDir = ""
 		err = stateMachine.makeDisk()
 		asserter.AssertErrContains(err, "Error writing disk image")
-		os.Remove(filepath.Join(stateMachine.commonFlags.OutputDir, "pc.img"))
 		helperCopyBlob = helper.CopyBlob
 	})
 }

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -759,6 +759,16 @@ func TestFailedMakeDisk(t *testing.T) {
 		diskfsCreate = diskfs.Create
 		os.Remove(filepath.Join(outDir, "pc.img")) // clean up for the next test run
 
+		// mock os.Truncate
+		osTruncate = mockTruncate
+		defer func() {
+			osTruncate = os.Truncate
+		}()
+		err = stateMachine.makeDisk()
+		asserter.AssertErrContains(err, "Error resizing disk image")
+		osTruncate = os.Truncate
+		os.Remove(filepath.Join(outDir, "pc.img")) // clean up for the next test run
+
 		// mock diskfs.Create to create a read only disk
 		diskfsCreate = readOnlyDiskfsCreate
 		defer func() {

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -702,7 +702,7 @@ func TestMakeDiskPartitionSchemes(t *testing.T) {
 			diskImg, err := diskfs.Open(imgFile)
 			defer diskImg.File.Close()
 			asserter.AssertErrNil(err, true)
-			if diskImg.Size % diskImg.LogicalBlocksize != 0 {
+			if diskImg.Size%diskImg.LogicalBlocksize != 0 {
 				t.Errorf("Disk image size %d is not an multiple of the block size: %d",
 					diskImg.Size, diskImg.LogicalBlocksize)
 			}

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -697,6 +697,15 @@ func TestMakeDiskPartitionSchemes(t *testing.T) {
 				t.Errorf("File %s should have partition table %s, instead got \"%s\"",
 					imgFile, tc.tableType, string(dumpe2fsBytes))
 			}
+
+			// ensure the resulting image file is a multiple of the block size
+			diskImg, err := diskfs.Open(imgFile)
+			defer diskImg.File.Close()
+			asserter.AssertErrNil(err, true)
+			if diskImg.Size % diskImg.LogicalBlocksize != 0 {
+				t.Errorf("Disk image size %d is not an multiple of the block size: %d",
+					diskImg.Size, diskImg.LogicalBlocksize)
+			}
 		})
 	}
 }

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -35,6 +35,7 @@ var osOpenFile = os.OpenFile
 var osRemoveAll = os.RemoveAll
 var osRename = os.Rename
 var osCreate = os.Create
+var osTruncate = os.Truncate
 var osutilCopyFile = osutil.CopyFile
 var osutilCopySpecialFile = osutil.CopySpecialFile
 var execCommand = exec.Command

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -87,6 +87,9 @@ func mockRemoveAll(string) error {
 func mockRename(string, string) error {
 	return fmt.Errorf("Test error")
 }
+func mockTruncate(string, int64) error {
+	return fmt.Errorf("Test error")
+}
 func mockCreate(string) (*os.File, error) {
 	return nil, fmt.Errorf("Test error")
 }


### PR DESCRIPTION
There was a UX difference between the python and Go versions that I wanted to clean up. If the Go tool was creating "pc.img" but that file already existed, it would throw an error. This change removes the old file if it exists and just creates the image if it doesn't. os.RemoveAll doesn't return an error if the file already doesn't exist.