### PR TITLE
Make sure we only generate unique disk IDs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-image (2.0+22.04ubuntu4) UNRELEASED; urgency=medium
+
+  * Make sure the generated disk IDs are unique.
+
+ -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Tue, 26 Oct 2021 13:14:27 +0200
+
 ubuntu-image (2.0+22.04ubuntu3) jammy; urgency=medium
 
   * Disable some tests on some architectures. This resolves failures

--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -1,7 +1,6 @@
 package statemachine
 
 import (
-	"crypto/rand"
 	"fmt"
 	"math"
 	"os"
@@ -278,6 +277,8 @@ func (stateMachine *StateMachine) makeDisk() error {
 			return fmt.Errorf("Error creating OutputDir: %s", err.Error())
 		}
 	}
+	// TODO: this is only temporarily needed until go-diskfs is fixed - see below
+	var existingDiskIds [][]byte
 	for volumeName, volume := range stateMachine.GadgetInfo.Volumes {
 		imgName := filepath.Join(stateMachine.commonFlags.OutputDir, volumeName+".img")
 
@@ -317,8 +318,10 @@ func (stateMachine *StateMachine) makeDisk() error {
 		// TODO: go-diskfs doesn't set the disk ID when using an MBR partition table.
 		// this function is a temporary workaround, but we should change upstream go-diskfs
 		if volume.Schema == "mbr" {
-			randomBytes := make([]byte, 4)
-			rand.Read(randomBytes)
+			randomBytes, err := generateUniqueDiskID(existingDiskIds)
+			if err != nil {
+				return fmt.Errorf("Error generating disk ID: %s", err.Error())
+			}
 			diskFile, err := osOpenFile(imgName, os.O_RDWR, 0755)
 			defer diskFile.Close()
 			if err != nil {

--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -318,7 +318,7 @@ func (stateMachine *StateMachine) makeDisk() error {
 		// TODO: go-diskfs doesn't set the disk ID when using an MBR partition table.
 		// this function is a temporary workaround, but we should change upstream go-diskfs
 		if volume.Schema == "mbr" {
-			randomBytes, err := generateUniqueDiskID(existingDiskIds)
+			randomBytes, err := generateUniqueDiskID(&existingDiskIds)
 			if err != nil {
 				return fmt.Errorf("Error generating disk ID: %s", err.Error())
 			}

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -872,8 +872,8 @@ func TestFailedMakeDisk(t *testing.T) {
 		asserter.AssertErrContains(err, "Error opening disk to write MBR disk identifier")
 		osOpenFile = os.OpenFile
 
-		// mock generateUniqueDiskID
-		// errors in generateUniqueDiskID TODO
+		// mock rand.Read
+		// errors in generateUniqueDiskID()
 		randRead = mockRandRead
 		defer func() {
 			randRead = rand.Read

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -3,6 +3,7 @@ package statemachine
 
 import (
 	"bytes"
+	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -870,6 +871,16 @@ func TestFailedMakeDisk(t *testing.T) {
 		err = stateMachine.makeDisk()
 		asserter.AssertErrContains(err, "Error opening disk to write MBR disk identifier")
 		osOpenFile = os.OpenFile
+
+		// mock generateUniqueDiskID
+		// errors in generateUniqueDiskID TODO
+		randRead = mockRandRead
+		defer func() {
+			randRead = rand.Read
+		}()
+		err = stateMachine.makeDisk()
+		asserter.AssertErrContains(err, "Error generating disk ID")
+		randRead = rand.Read
 
 		// mock os.OpenFile to force it to use os.O_APPEND, which causes
 		// errors in file.WriteAt()

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -519,14 +519,18 @@ func getStructureOffset(structure gadget.VolumeStructure) quantity.Offset {
 }
 
 // generateUniqueDiskID returns a random 4-byte long disk ID, unique per the list of existing IDs
-func generateUniqueDiskID(existing [][]byte) ([]byte, error) {
+func generateUniqueDiskID(existing *[][]byte) ([]byte, error) {
 	var retry bool
 	randomBytes := make([]byte, 4)
 	// we'll try 10 times, not to loop into infinity in case the RNG is broken (no entropy?)
 	for i := 0; i < 10; i++ {
 		retry = false
-		randRead(randomBytes)
-		for _, id := range existing {
+		_, err := randRead(randomBytes)
+		if err != nil {
+			retry = true
+			continue
+		}
+		for _, id := range *existing {
 			if bytes.Compare(randomBytes, id) == 0 {
 				retry = true
 				break
@@ -541,6 +545,6 @@ func generateUniqueDiskID(existing [][]byte) ([]byte, error) {
 		// this means for some weird reason we didn't get an unique ID after many retries
 		return nil, fmt.Errorf("Failed to generate unique disk ID. Random generator failure?")
 	}
-	existing = append(existing, randomBytes)
+	*existing = append(*existing, randomBytes)
 	return randomBytes, nil
 }

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -546,7 +546,6 @@ func TestGenerateUniqueDiskID(t *testing.T) {
 		{"one_time", [][]byte{[]byte{4, 5, 6, 7}}, [][]byte{[]byte{0, 1, 2, 3}}, []byte{0, 1, 2, 3}, false},
 		{"collision", [][]byte{[]byte{0, 1, 2, 3}}, [][]byte{[]byte{0, 1, 2, 3}, []byte{4, 5, 6, 7}}, []byte{4, 5, 6, 7}, false},
 		{"broken", [][]byte{[]byte{0, 0, 0, 0}}, nil, []byte{0, 0, 0, 0}, true},
-		//{"", gadget.VolumeStructure{Offset: &testOffset}, 1},
 	}
 	for _, tc := range testCases {
 		t.Run("test_generate_unique_diskid_"+tc.name, func(t *testing.T) {
@@ -568,13 +567,24 @@ func TestGenerateUniqueDiskID(t *testing.T) {
 				randRead = rand.Read
 			}()
 
-			randomBytes, err := generateUniqueDiskID(tc.existing)
+			randomBytes, err := generateUniqueDiskID(&tc.existing)
 			if tc.expectedErr {
 				asserter.AssertErrContains(err, "Failed to generate unique disk ID")
 			} else {
 				asserter.AssertErrNil(err, true)
 				if bytes.Compare(randomBytes, tc.expected) != 0 {
 					t.Errorf("Error, expected ID %v but got %v", tc.expected, randomBytes)
+				}
+				// check if the ID was added to the list of existing IDs
+				found := false
+				for _, id := range tc.existing {
+					if bytes.Compare(id, randomBytes) == 0 {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Error, disk ID not added to the existing list")
 				}
 			}
 		})

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1,6 +1,8 @@
 package statemachine
 
 import (
+	"bytes"
+	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -526,7 +528,54 @@ func TestGetStructureOffset(t *testing.T) {
 		t.Run("test_get_structure_offset_"+tc.name, func(t *testing.T) {
 			offset := getStructureOffset(tc.structure)
 			if offset != tc.expected {
-				t.Errorf("Error, expected offset %d but got %d", offset, tc.expected)
+				t.Errorf("Error, expected offset %d but got %d", tc.expected, offset)
+			}
+		})
+	}
+}
+
+// TestGenerateUniqueDiskID TODO
+func TestGenerateUniqueDiskID(t *testing.T) {
+	testCases := []struct {
+		name        string
+		existing    [][]byte
+		randomBytes [][]byte
+		expected    []byte
+		expectedErr bool
+	}{
+		{"one_time", [][]byte{[]byte{4, 5, 6, 7} }, [][]byte{[]byte{0, 1, 2, 3} }, []byte{0, 1, 2, 3}, false},
+		{"collision", [][]byte{[]byte{0, 1, 2, 3} }, [][]byte{[]byte{0, 1, 2, 3}, []byte{4, 5, 6, 7} }, []byte{4, 5, 6, 7}, false},
+		{"broken", [][]byte{[]byte{0, 0, 0, 0} }, nil, []byte{0, 0, 0, 0}, true},
+		//{"", gadget.VolumeStructure{Offset: &testOffset}, 1},
+	}
+	for _, tc := range testCases {
+		t.Run("test_generate_unique_diskid_"+tc.name, func(t *testing.T) {
+			asserter := helper.Asserter{T: t}
+			// create a test rng reader, using data from our testcase
+			ithRead := 0
+			randRead = func(output []byte) (int, error) {
+				var randomBytes []byte
+				if tc.randomBytes == nil || ithRead > (len(tc.randomBytes)-1) {
+					randomBytes = []byte{0, 0, 0, 0}
+				} else {
+					randomBytes = tc.randomBytes[ithRead]
+				}
+				copy(output, randomBytes)
+				ithRead++
+				return 0, nil
+			}
+			defer func() {
+				randRead = rand.Read
+			}()
+
+			randomBytes, err := generateUniqueDiskID(tc.existing)
+			if tc.expectedErr {
+				asserter.AssertErrContains(err, "Failed to generate unique disk ID")
+			} else {
+				asserter.AssertErrNil(err, true)
+				if bytes.Compare(randomBytes, tc.expected) != 0 {
+					t.Errorf("Error, expected ID %v but got %v", tc.expected, randomBytes)
+				}
 			}
 		})
 	}

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -543,9 +543,9 @@ func TestGenerateUniqueDiskID(t *testing.T) {
 		expected    []byte
 		expectedErr bool
 	}{
-		{"one_time", [][]byte{[]byte{4, 5, 6, 7} }, [][]byte{[]byte{0, 1, 2, 3} }, []byte{0, 1, 2, 3}, false},
-		{"collision", [][]byte{[]byte{0, 1, 2, 3} }, [][]byte{[]byte{0, 1, 2, 3}, []byte{4, 5, 6, 7} }, []byte{4, 5, 6, 7}, false},
-		{"broken", [][]byte{[]byte{0, 0, 0, 0} }, nil, []byte{0, 0, 0, 0}, true},
+		{"one_time", [][]byte{[]byte{4, 5, 6, 7}}, [][]byte{[]byte{0, 1, 2, 3}}, []byte{0, 1, 2, 3}, false},
+		{"collision", [][]byte{[]byte{0, 1, 2, 3}}, [][]byte{[]byte{0, 1, 2, 3}, []byte{4, 5, 6, 7}}, []byte{4, 5, 6, 7}, false},
+		{"broken", [][]byte{[]byte{0, 0, 0, 0}}, nil, []byte{0, 0, 0, 0}, true},
 		//{"", gadget.VolumeStructure{Offset: &testOffset}, 1},
 	}
 	for _, tc := range testCases {

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -534,7 +534,7 @@ func TestGetStructureOffset(t *testing.T) {
 	}
 }
 
-// TestGenerateUniqueDiskID TODO
+// TestGenerateUniqueDiskID ensures that we generate unique disk IDs
 func TestGenerateUniqueDiskID(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -3,6 +3,7 @@
 package statemachine
 
 import (
+	"crypto/rand"
 	"encoding/gob"
 	"fmt"
 	"io/ioutil"
@@ -41,6 +42,7 @@ var osutilCopySpecialFile = osutil.CopySpecialFile
 var execCommand = exec.Command
 var mkfsMakeWithContent = mkfs.MakeWithContent
 var diskfsCreate = diskfs.Create
+var randRead = rand.Read
 
 var mockableBlockSize string = "1" //used for mocking dd calls
 

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -102,6 +102,9 @@ func mockCopySpecialFile(string, string) error {
 func mockDiskfsCreate(string, int64, diskfs.Format) (*disk.Disk, error) {
 	return nil, fmt.Errorf("Test error")
 }
+func mockRandRead(output []byte) (int, error) {
+	return 0, fmt.Errorf("Test error")
+}
 func readOnlyDiskfsCreate(diskName string, size int64, format diskfs.Format) (*disk.Disk, error) {
 	diskFile, _ := os.OpenFile(diskName, os.O_RDONLY|os.O_CREATE, 0444)
 	disk := disk.Disk{


### PR DESCRIPTION
Okay, this is basically a sanity thing, a very very very unlikely case - but until we have this workaround in place, I think we should have a check for uniqueness. Since disk IDs need to be unique and we can't guarantee getting random unique bytes from the RNG.

...super low priority, but it just kept bugging me!