### PR TITLE
Fix naming of system-data partitions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,8 @@ ubuntu-image (2.0+22.04ubuntu4) UNRELEASED; urgency=medium
   [ William 'jawn-smith' Wilson ]
   * Pull in upstream change from go-diskfs to fix integer overflows on armhf
     (LP: #1949208)
+  * Add logic to name system-data partitions "writable" if a name isn't
+    specified (LP: #1951334)
 
  -- William 'jawn-smith' Wilson <william.wilson@canonical.com>  Tue, 02 Nov 2021 12:57:01 -0500
 

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -412,12 +412,19 @@ func createPartitionTable(volumeName string, volume *gadget.Volume, sectorSize u
 			}
 			mbrPartitions = append(mbrPartitions, mbrPartition)
 		} else {
+			var partitionName string
+			if structure.Role == "system-data" && structure.Name == "" {
+				partitionName = "writable"
+			} else {
+				partitionName = structure.Name
+			}
+
 			partitionType := gpt.Type(structureType)
 			gptPartition := &gpt.Partition{
 				Start: uint64(math.Ceil(float64(*structure.Offset) / float64(sectorSize))),
 				Size:  uint64(structure.Size),
 				Type:  partitionType,
-				Name:  structure.Name,
+				Name:  partitionName,
 			}
 			gptPartitions = append(gptPartitions, gptPartition)
 		}

--- a/internal/statemachine/snap_test.go
+++ b/internal/statemachine/snap_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -134,6 +135,15 @@ func TestSuccessfulSnapCore18(t *testing.T) {
 		_, err = os.Stat(grubenvFile)
 		if err != nil {
 			t.Errorf("Expected file %s to exist, but it does not", grubenvFile)
+		}
+
+		// check that the system-data partition has the name "writable"
+		diskImg := filepath.Join(workDir, "pc.img")
+		fdiskCommand := *exec.Command("fdisk", "-l", "-o", "Name", diskImg)
+
+		fdiskBytes, _ := fdiskCommand.CombinedOutput()
+		if !strings.Contains(string(fdiskBytes), "writable") {
+			t.Error("system-data partition is not named \"writable\"")
 		}
 
 		err = stateMachine.Teardown()


### PR DESCRIPTION
This was causing an issue with expanding the filesystems on some core images.