### PR TITLE
FR-1904 Use regex to label rootfs rather than clobbering fstab

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,7 @@ ubuntu-image (2.0+22.04ubuntu4) UNRELEASED; urgency=medium
     specified (LP: #1951334)
   * Add support for specifying a disk sector-size to use while building the
     images (LP: #1942416)
+  * Fix logic for filesystem labeling in /etc/fstab (LP: #1950677)
 
  -- William 'jawn-smith' Wilson <william.wilson@canonical.com>  Tue, 02 Nov 2021 12:57:01 -0500
 

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/canonical/ubuntu-image/internal/helper"
@@ -183,8 +184,12 @@ func (stateMachine *StateMachine) populateClassicRootfsContents() error {
 	}
 
 	if !strings.Contains(string(fstabBytes), "LABEL=writable") {
-		newFstab := []byte("LABEL=writable   /    ext4   defaults    0 0")
-		err := ioutilWriteFile(fstabPath, newFstab, 0644)
+		re := regexp.MustCompile(`(?m:^LABEL=\S+\s+/\s+(.*)$)`)
+		newContents := re.ReplaceAll(fstabBytes, []byte("LABEL=writable\t/\t$1")) 
+		if !strings.Contains(string(newContents), "LABEL=writable") {
+			newContents = []byte("LABEL=writable   /    ext4   defaults    0 0")
+		}
+		err := ioutilWriteFile(fstabPath, newContents, 0644)
 		if err != nil {
 			return fmt.Errorf("Error writing to fstab: %s", err.Error())
 		}

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -185,7 +185,7 @@ func (stateMachine *StateMachine) populateClassicRootfsContents() error {
 
 	if !strings.Contains(string(fstabBytes), "LABEL=writable") {
 		re := regexp.MustCompile(`(?m:^LABEL=\S+\s+/\s+(.*)$)`)
-		newContents := re.ReplaceAll(fstabBytes, []byte("LABEL=writable\t/\t$1")) 
+		newContents := re.ReplaceAll(fstabBytes, []byte("LABEL=writable\t/\t$1"))
 		if !strings.Contains(string(newContents), "LABEL=writable") {
 			newContents = []byte("LABEL=writable   /    ext4   defaults    0 0")
 		}

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -277,13 +277,14 @@ func TestPopulateClassicRootfsContents(t *testing.T) {
 			}
 		}
 
-		// check /etc/fstab contents to test the regex part
+		// check /etc/fstab contents to test the scenario where the regex replaced an
+		// existing filesystem label with LABEL=writable
 		fstab, err := ioutilReadFile(filepath.Join(stateMachine.tempDirs.rootfs,
 			"etc", "fstab"))
 		if err != nil {
 			t.Errorf("Error reading fstab to check regex")
 		}
-		correctLabel := "LABEL=writable   /    ext4   defaults    0 0"
+		correctLabel := "LABEL=writable"
 		if !strings.Contains(string(fstab), correctLabel) {
 			t.Errorf("Expected fstab contents %s to contain %s",
 				string(fstab), correctLabel)
@@ -297,8 +298,8 @@ func TestPopulateClassicRootfsContents(t *testing.T) {
 			if strings.Contains(snap, "=") {
 				snap = strings.Split(snap, "=")[0]
 			}
-			filePath := filepath.Join(stateMachine.tempDirs.unpack,
-				"chroot", "var", "snap", snap)
+			filePath := filepath.Join(stateMachine.tempDirs.rootfs,
+				"var", "snap", snap)
 			if !osutil.FileExists(filePath) {
 				t.Errorf("File %s should exist but it does not", filePath)
 			}
@@ -409,6 +410,19 @@ func TestFilesystemFlag(t *testing.T) {
 		// check that the specified filesystem was copied over
 		if _, err := os.Stat(filepath.Join(stateMachine.tempDirs.rootfs, "testfile")); err != nil {
 			t.Errorf("Failed to copy --filesystem to rootfs")
+		}
+
+		// the included filesystem contains an invalid /etc/fstab. Make sure it
+		// was overwritten to have a valid /etc/fstab
+		fstab, err := ioutilReadFile(filepath.Join(stateMachine.tempDirs.rootfs,
+			"etc", "fstab"))
+		if err != nil {
+			t.Errorf("Error reading fstab to check regex")
+		}
+		correctLabel := "LABEL=writable   /    ext4   defaults    0 0"
+		if !strings.Contains(string(fstab), correctLabel) {
+			t.Errorf("Expected fstab contents %s to contain %s",
+				string(fstab), correctLabel)
 		}
 	})
 }

--- a/internal/statemachine/testdata/filesystem/etc/fstab
+++ b/internal/statemachine/testdata/filesystem/etc/fstab
@@ -1,1 +1,1 @@
-LABEL=cloudimg-rootfs   /    ext4   defaults    0 0
+sample file


### PR DESCRIPTION
Closes #29 

Uses regex instead of just clobbering the fstab.