### PR TITLE
update tests for new hello dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-image (2.1+22.04ubuntu3) UNRELEASED; urgency=medium
+
+  * Update tests to reflect changes in the hello snap
+
+ -- William 'jawn-smith' Wilson <jawn-smith@ubuntu.com>  Thu, 13 Jan 2022 22:40:24 -0600
+
 ubuntu-image (2.1+22.04ubuntu2) jammy; urgency=medium
 
   * Create rootfs partitions with OffsetWrite nil instead of zero

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -252,7 +252,7 @@ func TestPopulateClassicRootfsContents(t *testing.T) {
 		stateMachine.Opts.Project = "ubuntu-cpc"
 		stateMachine.Opts.Suite = "focal"
 		stateMachine.Args.GadgetTree = filepath.Join("testdata", "gadget_tree")
-		stateMachine.commonFlags.Snaps = []string{"hello", "ubuntu-image/classic", "core20=beta"}
+		stateMachine.commonFlags.Snaps = []string{"hello", "ubuntu-image/classic=edge", "core20=beta"}
 		stateMachine.stateMachineFlags.Thru = "populate_rootfs_contents"
 
 		err := stateMachine.Setup()

--- a/internal/statemachine/snap_test.go
+++ b/internal/statemachine/snap_test.go
@@ -405,10 +405,10 @@ func TestSnapFlagSyntax(t *testing.T) {
 		snapArgs []string
 		valid    bool
 	}{
-		{"no_channel_specified", []string{"hello"}, true},
-		{"channel_specified", []string{"hello=edge"}, true},
-		{"mixed_syntax", []string{"hello", "core=edge"}, true},
-		{"invalid_syntax", []string{"hello=edge=stable"}, false},
+		{"no_channel_specified", []string{"hello", "core20"}, true},
+		{"channel_specified", []string{"hello=edge", "core20"}, true},
+		{"mixed_syntax", []string{"hello", "core20=edge"}, true},
+		{"invalid_syntax", []string{"hello=edge=stable", "core20"}, false},
 	}
 	for _, tc := range testCases {
 		t.Run("test_snap_flag_syntax_"+tc.name, func(t *testing.T) {


### PR DESCRIPTION
This is needed because the hello snap was updated to no longer depend on core, but rather core20.