### PR TITLE
many: add basic spread test to run as a GH workflow

### DIFF
--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -1,0 +1,22 @@
+name: Run a spread test of the generated snap
+
+on: [pull_request]
+
+jobs:
+  spread:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        system:
+          - ubuntu-18.04
+          - ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Download spread
+        run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | tar -xz
+      - name: Init lxd
+        run: sudo lxd init --auto
+      - name: Run spread tests
+        run: sudo ./spread lxd:${{ matrix.system }}

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,21 @@
+project: ubuntu-image
+
+backends:
+  lxd:
+    systems:
+      - ubuntu-18.04
+      - ubuntu-20.04
+      - ubuntu-22.04
+
+path: /home/ubuntu-image
+
+prepare: |
+  apt update
+  apt install snapd
+  snap install --classic snapcraft
+  snapcraft --destructive-mode
+  snap install --classic --dangerous ubuntu-image_*.snap
+
+suites:
+  tests/:
+    summary: Integration tests for ubuntu-image

--- a/tests/basic/task.yaml
+++ b/tests/basic/task.yaml
@@ -1,0 +1,3 @@
+summary: Run ubuntu-image smoke test
+execute: |
+    ubuntu-image --help | MATCH '^Usage:'


### PR DESCRIPTION
This commit adds a basic spread test that is also
run as a GH workflow. To run it locally install
spread and run:
```
$ spread lxd
```
or
```
$ spread lxd:ubuntu-20.04:tests/basic/
```

At this point it only checks that the snap is
build/instals/runs correctly. However it should
allow doing more sophisticated tests during the GH
action by simply adding some more shell like tests
that drive u-i via the commandline.

Setting to draft for now because I'm not sure how much
you like this and how much it adds over your existing tests.
I hope it's useful for you, if not that's fine of course :)