### PR TITLE
Fix, once and for all, issues with libfakeroot being called from outside the snap environment

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,10 +3,14 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 2.1+snap4
+version: 2.1+snap5
 grade: stable
 confinement: classic
 base: core20
+
+# Force the snap to only use binaries staged with the snap
+environment:
+  PATH: $SNAP/usr/local/sbin:$SNAP/usr/bin:$SNAP/bin:$SNAP/sbin:$SNAP/usr/local/bin:$SNAP/usr/sbin
 
 apps:
   ubuntu-image:
@@ -16,7 +20,6 @@ parts:
   ubuntu-image:
     plugin: go
     source: .
-    source-type: git
     build-packages:
       - golang-go
       - fdisk
@@ -30,3 +33,17 @@ parts:
       - e2fsprogs
       - fakeroot
       - dosfstools
+      - squashfs-tools
+      - coreutils
+      - util-linux
+      - sed
+    override-build: |
+      snapcraftctl build
+      cd $SNAPCRAFT_PART_INSTALL/usr/bin/
+      # create a symlink /usr/bin/fakeroot -> /usr/bin/fakeroot-tcp
+      ln -s fakeroot-tcp fakeroot
+      # fakeroot hard codes the library paths. To avoid using the libfakeroot from
+      # the host system, we replace the line in the fakeroot wrapper script
+      sed -i 's/PATHS=.*/PATHS=\${SNAP}\/usr\/lib\/lib-arch\/libfakeroot\//' fakeroot-tcp
+      cd $SNAPCRAFT_PART_INSTALL/usr/lib/
+      ln -s *-linux-gnu* lib-arch

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,6 +20,7 @@ parts:
   ubuntu-image:
     plugin: go
     source: .
+    source-type: git
     build-packages:
       - golang-go
       - fdisk

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,6 +11,7 @@ base: core20
 # Force the snap to only use binaries staged with the snap
 environment:
   PATH: $SNAP/usr/local/sbin:$SNAP/usr/bin:$SNAP/bin:$SNAP/sbin:$SNAP/usr/local/bin:$SNAP/usr/sbin
+  FAKEROOT_LIB: $SNAP/usr/lib/lib-arch/libfakeroot/libfakeroot-tcp.so
 
 apps:
   ubuntu-image:
@@ -43,9 +44,6 @@ parts:
       # create a symlink /usr/bin/fakeroot -> /usr/bin/fakeroot-tcp
       cd $SNAPCRAFT_PART_INSTALL/usr/bin/
       ln -s fakeroot-tcp fakeroot
-      # fakeroot hard codes the library paths. To avoid using the libfakeroot from
-      # the host system, we replace the line in the fakeroot wrapper script
-      sed -i 's/PATHS=.*/PATHS=\${SNAP}\/usr\/lib\/lib-arch\/libfakeroot\//' fakeroot-tcp
       # Create a symbolic link to /usr/lib/<arch> where libfakeroot will live
       cd $SNAPCRAFT_PART_INSTALL/usr/lib/
       ln -s *-linux-gnu* lib-arch

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -40,11 +40,12 @@ parts:
       - sed
     override-build: |
       snapcraftctl build
-      cd $SNAPCRAFT_PART_INSTALL/usr/bin/
       # create a symlink /usr/bin/fakeroot -> /usr/bin/fakeroot-tcp
+      cd $SNAPCRAFT_PART_INSTALL/usr/bin/
       ln -s fakeroot-tcp fakeroot
       # fakeroot hard codes the library paths. To avoid using the libfakeroot from
       # the host system, we replace the line in the fakeroot wrapper script
       sed -i 's/PATHS=.*/PATHS=\${SNAP}\/usr\/lib\/lib-arch\/libfakeroot\//' fakeroot-tcp
+      # Create a symbolic link to /usr/lib/<arch> where libfakeroot will live
       cd $SNAPCRAFT_PART_INSTALL/usr/lib/
       ln -s *-linux-gnu* lib-arch


### PR DESCRIPTION
The changes to snapcraft.yaml address the following issues:

- Setting the environment variable PATH to be much more restrictive, and _only_ contain entries within $SNAP/
- Staging new packages that were not present in the snap previously, as they are now needed with the more restrictive $PATH
- Create a symbolic link /usr/bin/fakeroot -> /usr/bin/fakeroot-tcp. Because of the more restrictive $PATH, fakeroot is now being called from inside $SNAP. This causes problems, because /usr/bin/fakeroot is usually a symbolic link generated by update-alternatives. We create it manually instead, and point to fakeroot-tcp as it is the more modern alternative
- Set an environment variable to point to the correct libfakeroot to be loaded by the fakeroot binary. Along with a change in snapd, this will stop fakeroot from loading an incompatible library.