### PR TITLE
Improve spread

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -5,7 +5,6 @@ backends:
     systems:
       - ubuntu-18.04
       - ubuntu-20.04
-      - ubuntu-22.04
 
 path: /home/ubuntu-image
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -5,6 +5,7 @@ backends:
     systems:
       - ubuntu-18.04
       - ubuntu-20.04
+        #- ubuntu-22.04
 
 path: /home/ubuntu-image
 

--- a/tests/basic/task.yaml
+++ b/tests/basic/task.yaml
@@ -1,3 +1,5 @@
 summary: Run ubuntu-image smoke test
 execute: |
     ubuntu-image --help | MATCH '^Usage:'
+    ubuntu-image snap /home/ubuntu-image/internal/statemachine/testdata/modelAssertion18
+    ubuntu-image snap /home/ubuntu-image/internal/statemachine/testdata/modelAssertion20


### PR DESCRIPTION
I'm removing ubuntu-22.04 for now as lxd fails with "image not found". It's just commented out to remind us to add it back in later.

The more important part though is having the spread tests actually build a core18 and core20 image in each of the lxd environments. This should help catch issues similar to the libfakeroot/mkfs environment mix-ups that we recently fixed.