### PR TITLE
Allow for no fstab during classic image builds.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,13 @@
 ubuntu-image (2.1+22.04ubuntu4) UNRELEASED; urgency=medium
 
+  [ Łukasz 'sil2100' Zemczak ]
   * Allow for no fstab in the rootfs for classic image builds.
+
+  [ William 'jawn-smith' Wilson ]
+  * Fix use of --snap flag with the --filesystem flag (LP: #1958275)
+
+  [ Alfonso Sanchez-Beato ]
+  * Add support for the piboot bootloader
 
  -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Fri, 18 Mar 2022 17:15:10 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-image (2.1+22.04ubuntu4) UNRELEASED; urgency=medium
+
+  * Allow for no fstab in the rootfs for classic image builds.
+
+ -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Fri, 18 Mar 2022 17:15:10 +0100
+
 ubuntu-image (2.1+22.04ubuntu3) jammy; urgency=medium
 
   * Update tests to reflect changes in the hello snap

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -223,19 +223,17 @@ func (stateMachine *StateMachine) populateClassicRootfsContents() error {
 
 	fstabPath := filepath.Join(classicStateMachine.tempDirs.rootfs, "etc", "fstab")
 	fstabBytes, err := ioutilReadFile(fstabPath)
-	if err != nil {
-		return fmt.Errorf("Error opening fstab: %s", err.Error())
-	}
-
-	if !strings.Contains(string(fstabBytes), "LABEL=writable") {
-		re := regexp.MustCompile(`(?m:^LABEL=\S+\s+/\s+(.*)$)`)
-		newContents := re.ReplaceAll(fstabBytes, []byte("LABEL=writable\t/\t$1"))
-		if !strings.Contains(string(newContents), "LABEL=writable") {
-			newContents = []byte("LABEL=writable   /    ext4   defaults    0 0")
-		}
-		err := ioutilWriteFile(fstabPath, newContents, 0644)
-		if err != nil {
-			return fmt.Errorf("Error writing to fstab: %s", err.Error())
+	if err == nil {
+		if !strings.Contains(string(fstabBytes), "LABEL=writable") {
+			re := regexp.MustCompile(`(?m:^LABEL=\S+\s+/\s+(.*)$)`)
+			newContents := re.ReplaceAll(fstabBytes, []byte("LABEL=writable\t/\t$1"))
+			if !strings.Contains(string(newContents), "LABEL=writable") {
+				newContents = []byte("LABEL=writable   /    ext4   defaults    0 0")
+			}
+			err := ioutilWriteFile(fstabPath, newContents, 0644)
+			if err != nil {
+				return fmt.Errorf("Error writing to fstab: %s", err.Error())
+			}
 		}
 	}
 

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -344,15 +344,6 @@ func TestFailedPopulateClassicRootfsContents(t *testing.T) {
 		asserter.AssertErrContains(err, "Error copying rootfs")
 		osutilCopySpecialFile = osutil.CopySpecialFile
 
-		// mock ioutil.ReadFile
-		ioutilReadFile = mockReadFile
-		defer func() {
-			ioutilReadFile = ioutil.ReadFile
-		}()
-		err = stateMachine.populateClassicRootfsContents()
-		asserter.AssertErrContains(err, "Error opening fstab")
-		ioutilReadFile = ioutil.ReadFile
-
 		// mock ioutil.WriteFile
 		ioutilWriteFile = mockWriteFile
 		defer func() {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 2.1+snap5
+version: 2.1+snap6
 grade: stable
 confinement: classic
 base: core20


### PR DESCRIPTION
In certain cases, we might not have an `/etc/fstab` - and that's fine. The Python version was simply skipping fstab modifications in such case.