### PR TITLE
Remove restrictive PATH environment variable

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,14 +3,13 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 2.1+snap6
+version: 2.1+snap7
 grade: stable
 confinement: classic
 base: core20
 
-# Force the snap to only use binaries staged with the snap
+# Force the snap to use fakeroot staged within the snap
 environment:
-  PATH: $SNAP/usr/local/sbin:$SNAP/usr/bin:$SNAP/bin:$SNAP/sbin:$SNAP/usr/local/bin:$SNAP/usr/sbin
   FAKEROOT_FLAGS: "--lib $SNAP/usr/lib/lib-arch/libfakeroot/libfakeroot-tcp.so --faked $SNAP/usr/bin/faked-tcp"
 
 apps:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -35,9 +35,6 @@ parts:
       - fakeroot
       - dosfstools
       - squashfs-tools
-      - coreutils
-      - util-linux
-      - sed
     override-build: |
       snapcraftctl build
       # create a symlink /usr/bin/fakeroot -> /usr/bin/fakeroot-tcp


### PR DESCRIPTION
I want to start another conversation about this.

That PATH environment variable was originally added as an attempt to fix the fakeroot issues. That's now handled in another way, and restricting PATH this much was causing other problems. The new snapd has an `sh` call, and since we weren't staging `dash` that was failing. If we keep trying to make ubuntu-image behave as a strictly confined snap, we'll have to keep chasing down these missing commands forever.

The snap currently works without the PATH environment variable. I can't guarantee that it will always work, but that's just inevitable with classically confined snaps.

I think as we redesign the classic build story without hooks, this should become a strictly confined snap. For now, to make the new piboot changes work, the path either needs to be come less restricted or we need to start staging more binaries. Let's have a discussion about that.