### PR TITLE
Add logic to not copy structure content if the structure has no content

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ ubuntu-image (2.1+22.04ubuntu4) UNRELEASED; urgency=medium
 
   [ William 'jawn-smith' Wilson ]
   * Fix use of --snap flag with the --filesystem flag (LP: #1958275)
+  * Fix bug with attempting to create partition with no content
 
   [ Alfonso Sanchez-Beato ]
   * Add support for the piboot bootloader (LP: #1965585)

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -216,10 +216,12 @@ func (stateMachine *StateMachine) copyStructureContent(volume *gadget.Volume,
 					partImg, err.Error())
 			}
 		}
-		err := mkfsMakeWithContent(structure.Filesystem, partImg, structure.Label,
-			contentRoot, structure.Size, stateMachine.SectorSize)
-		if err != nil {
-			return fmt.Errorf("Error running mkfs: %s", err.Error())
+		if structure.Content != nil {
+			err := mkfsMakeWithContent(structure.Filesystem, partImg, structure.Label,
+				contentRoot, structure.Size, stateMachine.SectorSize)
+			if err != nil {
+				return fmt.Errorf("Error running mkfs: %s", err.Error())
+			}
 		}
 	}
 	return nil

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -402,8 +402,19 @@ func TestFailedCopyStructureContent(t *testing.T) {
 		}()
 		err = stateMachine.copyStructureContent(volume, rootfsStruct, 0, "",
 			filepath.Join("/tmp", uuid.NewString()+".img"))
-		asserter.AssertErrContains(err, "Error running mkfs")
+		asserter.AssertErrContains(err, "Error running mkfs with content")
 		mkfsMakeWithContent = mkfs.MakeWithContent
+
+		// mock mkfs.Mkfs
+		rootfsStruct.Content = nil // to trigger the "empty partition" case
+		mkfsMake = mockMkfs
+		defer func() {
+			mkfsMake = mkfs.Make
+		}()
+		err = stateMachine.copyStructureContent(volume, rootfsStruct, 0, "",
+			filepath.Join("/tmp", uuid.NewString()+".img"))
+		asserter.AssertErrContains(err, "Error running mkfs")
+		mkfsMake = mkfs.Make
 	})
 }
 

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -43,6 +43,7 @@ var osutilCopyFile = osutil.CopyFile
 var osutilCopySpecialFile = osutil.CopySpecialFile
 var execCommand = exec.Command
 var mkfsMakeWithContent = mkfs.MakeWithContent
+var mkfsMake = mkfs.Make
 var diskfsCreate = diskfs.Create
 var randRead = rand.Read
 var seedOpen = seed.Open

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -62,6 +62,9 @@ func mockNewMountedFilesystemWriter(*gadget.LaidOutStructure,
 func mockMkfsWithContent(typ, img, label, contentRootDir string, deviceSize, sectorSize quantity.Size) error {
 	return fmt.Errorf("Test Error")
 }
+func mockMkfs(typ, img, label string, deviceSize, sectorSize quantity.Size) error {
+	return fmt.Errorf("Test Error")
+}
 func mockReadDir(string) ([]os.FileInfo, error) {
 	return []os.FileInfo{}, fmt.Errorf("Test Error")
 }


### PR DESCRIPTION
See https://forum.snapcraft.io/t/gadget-with-extra-partition/29134 for the reasoning behind this.

Before merging, we should discuss here what the actual intended behavior is for the extra "system-data" partition being added in gadget.yaml (without the role as snapd won't allow two "system-data" partitions).