### PR TITLE
pull in new version of snapd for piboot on armhf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/mvo5/goconfigparser v0.0.0-20201015074339-50f22f44deb5 // indirect
 	github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2 // indirect
-	github.com/snapcore/snapd v0.0.0-20220318100237-fec3ee36690c
+	github.com/snapcore/snapd v0.0.0-20220401082319-bc390e47b70a
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	gopkg.in/macaroon.v1 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,10 +66,8 @@ github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2/go.mod h1:D3Ss
 github.com/snapcore/secboot v0.0.0-20211018143212-802bb19ca263 h1:cq2rG4JcNBCwHvo7iNdJL4nb8Ns7L/aOUd1EFs2toFs=
 github.com/snapcore/secboot v0.0.0-20211018143212-802bb19ca263/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
-github.com/snapcore/snapd v0.0.0-20220207153948-05eadd8176a7 h1:Q3UbFJgfIdFAIY0Gq/3/Dk50ec6jHL+CUxjd4HldJP4=
-github.com/snapcore/snapd v0.0.0-20220207153948-05eadd8176a7/go.mod h1:Ypuk/H7dwlEFWXBJBhq8PFDwZxcyN5bfxNAAMBRPaDI=
-github.com/snapcore/snapd v0.0.0-20220318100237-fec3ee36690c h1:VhJYLKfq0zNpGjHi6cTYlmURHnafwGcFU+0qPyX5d50=
-github.com/snapcore/snapd v0.0.0-20220318100237-fec3ee36690c/go.mod h1:Ypuk/H7dwlEFWXBJBhq8PFDwZxcyN5bfxNAAMBRPaDI=
+github.com/snapcore/snapd v0.0.0-20220401082319-bc390e47b70a h1:QIM212/5BC+XIJr/tsxoKCvTFRsYwbxZUIFs0jV0fEQ=
+github.com/snapcore/snapd v0.0.0-20220401082319-bc390e47b70a/go.mod h1:Ypuk/H7dwlEFWXBJBhq8PFDwZxcyN5bfxNAAMBRPaDI=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=


### PR DESCRIPTION
The armhf piboot PR in snapd has been merged, so pulling this new version in will fix piboot builds on armhf. I'll test the created images and report back here.