### PR TITLE
internal/statemachine: load snaps from all modes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/mvo5/goconfigparser v0.0.0-20201015074339-50f22f44deb5 // indirect
 	github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2 // indirect
-	github.com/snapcore/snapd v0.0.0-20220401082319-bc390e47b70a
+	github.com/snapcore/snapd v0.0.0-20220411132918-d69f2ac36bd2
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	gopkg.in/macaroon.v1 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2/go.mod h1:D3Ss
 github.com/snapcore/secboot v0.0.0-20211018143212-802bb19ca263 h1:cq2rG4JcNBCwHvo7iNdJL4nb8Ns7L/aOUd1EFs2toFs=
 github.com/snapcore/secboot v0.0.0-20211018143212-802bb19ca263/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
-github.com/snapcore/snapd v0.0.0-20220401082319-bc390e47b70a h1:QIM212/5BC+XIJr/tsxoKCvTFRsYwbxZUIFs0jV0fEQ=
-github.com/snapcore/snapd v0.0.0-20220401082319-bc390e47b70a/go.mod h1:Ypuk/H7dwlEFWXBJBhq8PFDwZxcyN5bfxNAAMBRPaDI=
+github.com/snapcore/snapd v0.0.0-20220411132918-d69f2ac36bd2 h1:hu/d6YhU12uWCT3dh5MRr11YK0ZnWcvS+KTANLatTM8=
+github.com/snapcore/snapd v0.0.0-20220411132918-d69f2ac36bd2/go.mod h1:Ypuk/H7dwlEFWXBJBhq8PFDwZxcyN5bfxNAAMBRPaDI=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -611,7 +611,7 @@ func removePreseeding(rootfs string) (seededSnaps map[string]string, err error) 
 	if err := preseed.LoadAssertions(nil, nil); err != nil {
 		return seededSnaps, err
 	}
-	if err := preseed.LoadMeta(measurer); err != nil {
+	if err := preseed.LoadMeta(seed.AllModes, measurer); err != nil {
 		return seededSnaps, err
 	}
 


### PR DESCRIPTION
Update to the latest master version of snapd, and match the changes in snapd's API. This is needed to unblock snapd to use a locally built variant of ubuntu-image.