### PR TITLE
Fix failing autopkgtest cases

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-image (2.2+22.04ubuntu2) UNRELEASED; urgency=medium
+
+  * Fix failing autopkgtests:
+    - Restrict test using snap prepare-image --arch=amd64 to only run on amd64
+    - Increase size of 4k volume to have enough sectors to be valid fat32
+
+ -- William 'jawn-smith' Wilson <jawn-smith@ubuntu.com>  Wed, 13 Apr 2022 10:49:05 -0500
+
 ubuntu-image (2.2+22.04ubuntu1) jammy; urgency=medium
 
   [ Łukasz 'sil2100' Zemczak ]

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -548,6 +548,9 @@ func TestFailedRunLiveBuild(t *testing.T) {
 // in the resulting root filesystem
 func TestExtraSnapsWithFilesystem(t *testing.T) {
 	t.Run("test_extra_snaps_with_filesystem", func(t *testing.T) {
+		if runtime.GOARCH != "amd64" {
+			t.Skip("Test for amd64 only")
+		}
 		asserter := helper.Asserter{T: t}
 		var stateMachine ClassicStateMachine
 		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()

--- a/internal/statemachine/testdata/gadget-gpt4k.yaml
+++ b/internal/statemachine/testdata/gadget-gpt4k.yaml
@@ -19,7 +19,7 @@ volumes:
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
         filesystem-label: system-boot
-        size: 50M
+        size: 512M
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi


### PR DESCRIPTION
Some autopkgtests are failing for the following reasons:

Behavior of mcopy has changed to fail when trying to mcopy a vfat filesystem that is has fewer than 65526 sectors.

`snap prepare-image --arch=amd64` does not work on architectures other than amd64.

This PR fixes both of these issues.