### PR TITLE
Support new uc20 preseed-related options

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-image (2.2+22.04ubuntu4) UNRELEASED; urgency=medium
+
+  * Add support for uc20 preseeding-related options.
+
+ -- Pawel Stolowski <pawel.stolowski@ubuntu.com>  Wed, 11 May 2022 08:16:21 +0000
+
 ubuntu-image (2.2+22.04ubuntu3) jammy; urgency=medium
 
   [ William 'jawn-smith' Wilson ]

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/mvo5/goconfigparser v0.0.0-20201015074339-50f22f44deb5 // indirect
 	github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2 // indirect
-	github.com/snapcore/snapd v0.0.0-20220504063749-08e22fe6c2a0
+	github.com/snapcore/snapd v0.0.0-20220510181928-39f97113c151
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	gopkg.in/macaroon.v1 v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/mvo5/goconfigparser v0.0.0-20201015074339-50f22f44deb5 // indirect
 	github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2 // indirect
-	github.com/snapcore/snapd v0.0.0-20220426105407-5b97b04f7d11
+	github.com/snapcore/snapd v0.0.0-20220504063749-08e22fe6c2a0
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	gopkg.in/macaroon.v1 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9Se4YQIRkDTCw1EJls9xTUCaCeRM=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210917151616-9da99da69b1b/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8 h1:WmyDfH38e3MaMWrMCO5YpW96BANq5Ti2iwbliM/xTW0=
@@ -72,6 +73,8 @@ github.com/snapcore/snapd v0.0.0-20220426105407-5b97b04f7d11 h1:oCJ62wP7V/7e2Ldx
 github.com/snapcore/snapd v0.0.0-20220426105407-5b97b04f7d11/go.mod h1:Ypuk/H7dwlEFWXBJBhq8PFDwZxcyN5bfxNAAMBRPaDI=
 github.com/snapcore/snapd v0.0.0-20220504063749-08e22fe6c2a0 h1:TBnniDRu5OjSQB2iJh0yu4VCqfvYo8grixwlmWMPFKo=
 github.com/snapcore/snapd v0.0.0-20220504063749-08e22fe6c2a0/go.mod h1:Ypuk/H7dwlEFWXBJBhq8PFDwZxcyN5bfxNAAMBRPaDI=
+github.com/snapcore/snapd v0.0.0-20220510181928-39f97113c151 h1:SBeV83rDl5iwivm+uHspZbzhQsDDcYSDFU+/sVeq/tI=
+github.com/snapcore/snapd v0.0.0-20220510181928-39f97113c151/go.mod h1:Ab4TsNgVast9nXAN8KVydI5G/hTHncgiQ4S1sAWjIXg=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/snapcore/snapd v0.0.0-20220411132918-d69f2ac36bd2 h1:hu/d6YhU12uWCT3d
 github.com/snapcore/snapd v0.0.0-20220411132918-d69f2ac36bd2/go.mod h1:Ypuk/H7dwlEFWXBJBhq8PFDwZxcyN5bfxNAAMBRPaDI=
 github.com/snapcore/snapd v0.0.0-20220426105407-5b97b04f7d11 h1:oCJ62wP7V/7e2Ldx5LC9I27Sz3mLxDK8321D+NOBA0c=
 github.com/snapcore/snapd v0.0.0-20220426105407-5b97b04f7d11/go.mod h1:Ypuk/H7dwlEFWXBJBhq8PFDwZxcyN5bfxNAAMBRPaDI=
+github.com/snapcore/snapd v0.0.0-20220504063749-08e22fe6c2a0 h1:TBnniDRu5OjSQB2iJh0yu4VCqfvYo8grixwlmWMPFKo=
+github.com/snapcore/snapd v0.0.0-20220504063749-08e22fe6c2a0/go.mod h1:Ypuk/H7dwlEFWXBJBhq8PFDwZxcyN5bfxNAAMBRPaDI=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=

--- a/internal/commands/snap.go
+++ b/internal/commands/snap.go
@@ -7,9 +7,14 @@ type SnapArgs struct {
 
 // SnapOpts holds all flags that are specific to the snap command
 type SnapOpts struct {
-	DisableConsoleConf bool   `long:"disable-console-conf" description:"Disable console-conf on the resulting image."`
-	FactoryImage       bool   `long:"factory-image" description:"Hint that the image is meant to boot in a device factory."`
-	Validation         string `long:"validation" description:"Control whether validations should be ignored or enforced" choice:"ignore" choice:"enforce"`
+	DisableConsoleConf bool `long:"disable-console-conf" description:"Disable console-conf on the resulting image."`
+	FactoryImage       bool `long:"factory-image" description:"Hint that the image is meant to boot in a device factory."`
+	Preseed            bool `long:"preseed" description:"Pressed the image (UC20 only)."`
+
+	AppArmorKernelFeaturesDir string `long:"apparmor-features-dir" description:"Optional path to apparmor kernel features directory"`
+	PreseedSignKey            string `long:"preseed-sign-key" description:"Name of the key to use to sign preseed assertion, otherwise use the default key"`
+
+	Validation string `long:"validation" description:"Control whether validations should be ignored or enforced" choice:"ignore" choice:"enforce"`
 }
 
 type snapCommand struct {

--- a/internal/statemachine/snap_states.go
+++ b/internal/statemachine/snap_states.go
@@ -48,7 +48,7 @@ func (stateMachine *StateMachine) prepareImage() error {
 	// plug/slot sanitization not used by snap image.Prepare, make it no-op.
 	snap.SanitizePlugsSlots = func(snapInfo *snap.Info) {}
 
-	if err := image.Prepare(&imageOpts); err != nil {
+	if err := imagePrepare(&imageOpts); err != nil {
 		return fmt.Errorf("Error preparing image: %s", err.Error())
 	}
 

--- a/internal/statemachine/snap_states.go
+++ b/internal/statemachine/snap_states.go
@@ -29,6 +29,11 @@ func (stateMachine *StateMachine) prepareImage() error {
 		imageOpts.Channel = snapStateMachine.commonFlags.Channel
 	}
 
+	// preseeding-related
+	imageOpts.Preseed = snapStateMachine.Opts.Preseed
+	imageOpts.PreseedSignKey = snapStateMachine.Opts.PreseedSignKey
+	imageOpts.AppArmorKernelFeaturesDir = snapStateMachine.Opts.AppArmorKernelFeaturesDir
+
 	customizations := *new(image.Customizations)
 	if snapStateMachine.Opts.DisableConsoleConf {
 		customizations.ConsoleConf = "disabled"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 2.2+snap8
+version: 2.2+snap9
 grade: stable
 confinement: classic
 base: core20


### PR DESCRIPTION
Support `--preseed`, `--preseed-sign-key` and `--apparmor-features-dir` options required for uc20 preseeding with snap prepare-image.