### PR TITLE
Fix issue with incorrect offsets by not preserving map order

### DIFF
--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -73,15 +73,15 @@ func (stateMachine *StateMachine) loadGadgetYaml() error {
 		}
 	}
 
-	if err := stateMachine.postProcessGadgetYaml(); err != nil {
-		return err
-	}
-
 	// for the --image-size argument, the order of the volumes specified in gadget.yaml
 	// must be preserved. However, since gadget.Info stores the volumes as a map, the
 	// order is not preserved. We use the already read-in gadget.yaml file to store the
 	// order of the volumes as an array in the StateMachine struct
 	stateMachine.saveVolumeOrder(string(gadgetYamlBytes))
+
+	if err := stateMachine.postProcessGadgetYaml(); err != nil {
+		return err
+	}
 
 	if err := stateMachine.parseImageSizes(); err != nil {
 		return err
@@ -233,7 +233,8 @@ func (stateMachine *StateMachine) populateBootfsContents() error {
 // Throughout this process, the offset is tracked to ensure partitions are not overlapping.
 func (stateMachine *StateMachine) populatePreparePartitions() error {
 	// iterate through all the volumes
-	for volumeName, volume := range stateMachine.GadgetInfo.Volumes {
+	for _, volumeName := range stateMachine.VolumeOrder {
+		volume := stateMachine.GadgetInfo.Volumes[volumeName]
 		if err := stateMachine.handleLkBootloader(volume); err != nil {
 			return err
 		}

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -202,7 +202,8 @@ func (stateMachine *StateMachine) postProcessGadgetYaml() error {
 	var farthestOffset quantity.Offset = 0
 	var lastOffset quantity.Offset = 0
 	var lastVolumeName string
-	for volumeName, volume := range stateMachine.GadgetInfo.Volumes {
+	for _, volumeName := range stateMachine.VolumeOrder {
+		volume := stateMachine.GadgetInfo.Volumes[volumeName]
 		lastVolumeName = volumeName
 		volumeBaseDir := filepath.Join(stateMachine.tempDirs.volumes, volumeName)
 		if err := osMkdirAll(volumeBaseDir, 0755); err != nil {


### PR DESCRIPTION
Found another issue in the form of an occasionally failing test. If we don't postProcess the volumes in order, the offsets can get set incorrectly. Some day I might try to PR snapd to make volumes an ordered slice instead of a map.