### PR TITLE
Halt execution after printing states if the print-states flag is used

### DIFF
--- a/internal/commands/classic.go
+++ b/internal/commands/classic.go
@@ -8,7 +8,7 @@ type ClassicArgs struct {
 // ClassicOpts holds all flags that are specific to the classic command
 type ClassicOpts struct {
 	AptParams   []string `long:"apt-params" description:"Any additional APT specific configuration needed for the image build."`
-	PrintStates bool     `long:"print-states" description:"An additional debug logging option to print the states that will be executed by the state machine after they have been determined"`
+	PrintStates bool     `long:"print-states" description:"An additional debug logging option to print the states that will be executed by the state machine after they have been determined. Execution of the state machine will be halted after printing the states."`
 }
 
 type classicCommand struct {

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -169,6 +169,7 @@ func (stateMachine *StateMachine) calculateStates() error {
 		for i, state := range stateMachine.states {
 			fmt.Printf("[%d] %s\n", i, state.name)
 		}
+		osExit(0)
 	}
 
 	return nil

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -186,6 +186,18 @@ func TestPrintStates(t *testing.T) {
 		defer restoreStdout()
 		asserter.AssertErrNil(err, true)
 
+		// override os.Exit to capture the exit code
+		oldOsExit := osExit
+		defer func() {
+			osExit = oldOsExit
+		}()
+
+		var exitCode int
+		tmpExit := func(code int) {
+			exitCode = code
+		}
+
+		osExit = tmpExit
 		err = stateMachine.calculateStates()
 		asserter.AssertErrNil(err, true)
 
@@ -213,6 +225,10 @@ func TestPrintStates(t *testing.T) {
 		if string(readStdout) != expectedStates {
 			t.Errorf("Expected states to be printed in output:\n\"%s\"\n but got \n\"%s\"\n instead",
 				string(readStdout), expectedStates)
+		}
+
+		if exitCode != 0 {
+			t.Errorf("Expected exit code 0, got %d instead", exitCode)
 		}
 	})
 }

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -52,6 +52,7 @@ var randRead = rand.Read
 var seedOpen = seed.Open
 var imagePrepare = image.Prepare
 var gojsonschemaValidate = gojsonschema.Validate
+var osExit = os.Exit
 
 var mockableBlockSize string = "1" //used for mocking dd calls
 


### PR DESCRIPTION
@sil2100 per your comments on the previous PR, I have added logic to halt execution of the state machine after printing the states if the --print-states flag is used. I misunderstood what you wanted, and I do think this is a nicer workflow now that I think about it.