### PR TITLE
Check validity of thru and until flags after all states are decided

### DIFF
--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -174,6 +174,10 @@ func (stateMachine *StateMachine) calculateStates() error {
 		}
 	}
 
+	if err := stateMachine.validateUntilThru(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-//TestClassicSetup tests a successful run of the polymorphed Setup function
+// TestClassicSetup tests a successful run of the polymorphed Setup function
 func TestClassicSetup(t *testing.T) {
 	t.Run("test_classic_setup", func(t *testing.T) {
 		asserter := helper.Asserter{T: t}
@@ -120,6 +120,7 @@ func TestFailedParseImageDefinition(t *testing.T) {
 
 // TestCalculateStates reads in a variety of yaml files and ensures
 // that the correct states are added to the state machine
+// TODO: manually assemble the image definitions instead of relying on the parseImageDefinition() function to make this more of a unit test
 func TestCalculateStates(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -164,6 +165,36 @@ func TestCalculateStates(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFailedCalculateStates tests that the calculateStates
+// function fails if the value of --until or --thru is not
+// in the calculated list of states
+func TestFailedCalculateStates(t *testing.T) {
+	t.Run("test_failed_calcluate_states", func(t *testing.T) {
+		asserter := helper.Asserter{T: t}
+		saveCWD := helper.SaveCWD()
+		defer saveCWD()
+
+		var stateMachine ClassicStateMachine
+		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+		stateMachine.parent = &stateMachine
+		stateMachine.ImageDef = ImageDefinition{
+			Gadget: &GadgetType{
+				GadgetType: "git",
+			},
+			Rootfs: &RootfsType{
+				ArchiveTasks: []string{"test"},
+			},
+			Customization: &CustomizationType{},
+		}
+
+		stateMachine.stateMachineFlags.Thru = "fake_state"
+
+		// now calculate the states and ensure that the expected states are in the slice
+		err := stateMachine.calculateStates()
+		asserter.AssertErrContains(err, "not a valid state name")
+	})
 }
 
 // TestPrintStates ensures the states are printed to stdout when the flag is set

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -35,6 +35,12 @@ func (stateMachine *StateMachine) validateInput() error {
 		return fmt.Errorf("must specify workdir when using --resume flag")
 	}
 
+	return nil
+}
+
+// validateUntilThru validates that the the state passed as --until
+// or --thru exists in the state machine's list of states
+func (stateMachine *StateMachine) validateUntilThru() error {
 	// if --until or --thru was given, make sure the specified state exists
 	var searchState string
 	var stateFound bool = false

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -777,3 +777,56 @@ func TestRemovePreseeding(t *testing.T) {
 		}
 	})
 }
+
+// TestValidateInput tests that invalid state machine command line arguments result in a failure
+func TestValidateInput(t *testing.T) {
+	testCases := []struct {
+		name   string
+		until  string
+		thru   string
+		resume bool
+		errMsg string
+	}{
+		{"both_until_and_thru", "make_temporary_directories", "calculate_rootfs_size", false, "cannot specify both --until and --thru"},
+		{"resume_with_no_workdir", "", "", true, "must specify workdir when using --resume flag"},
+	}
+	for _, tc := range testCases {
+		t.Run("test "+tc.name, func(t *testing.T) {
+			asserter := helper.Asserter{T: t}
+			var stateMachine StateMachine
+			stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+			stateMachine.stateMachineFlags.Until = tc.until
+			stateMachine.stateMachineFlags.Thru = tc.thru
+			stateMachine.stateMachineFlags.Resume = tc.resume
+
+			err := stateMachine.validateInput()
+			asserter.AssertErrContains(err, tc.errMsg)
+		})
+	}
+}
+
+// TestValidateUntilThru ensures that using invalid value for --thru
+// or --until returns an error
+func TestValidateUntilThru(t *testing.T) {
+	testCases := []struct {
+		name  string
+		until string
+		thru  string
+	}{
+		{"invalid_until_name", "fake step", ""},
+		{"invalid_thru_name", "", "fake step"},
+	}
+	for _, tc := range testCases {
+		t.Run("test "+tc.name, func(t *testing.T) {
+			asserter := helper.Asserter{T: t}
+			var stateMachine StateMachine
+			stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+			stateMachine.stateMachineFlags.Until = tc.until
+			stateMachine.stateMachineFlags.Thru = tc.thru
+
+			err := stateMachine.validateUntilThru()
+			asserter.AssertErrContains(err, "not a valid state name")
+
+		})
+	}
+}

--- a/internal/statemachine/snap.go
+++ b/internal/statemachine/snap.go
@@ -41,6 +41,11 @@ func (snapStateMachine *SnapStateMachine) Setup() error {
 		return err
 	}
 
+	// validate values of until and thru
+	if err := snapStateMachine.validateUntilThru(); err != nil {
+		return err
+	}
+
 	// if --resume was passed, figure out where to start
 	if err := snapStateMachine.readMetadata(); err != nil {
 		return err

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -270,36 +270,6 @@ func TestUntilThru(t *testing.T) {
 	}
 }
 
-// TestInvalidStateMachineArgs tests that invalid state machine command line arguments result in a failure
-func TestInvalidStateMachineArgs(t *testing.T) {
-	testCases := []struct {
-		name   string
-		until  string
-		thru   string
-		resume bool
-		errMsg string
-	}{
-		{"both_until_and_thru", "make_temporary_directories", "calculate_rootfs_size", false, "cannot specify both --until and --thru"},
-		{"invalid_until_name", "fake step", "", false, "not a valid state name"},
-		{"invalid_thru_name", "", "fake step", false, "not a valid state name"},
-		{"resume_with_no_workdir", "", "", true, "must specify workdir when using --resume flag"},
-	}
-
-	for _, tc := range testCases {
-		t.Run("test "+tc.name, func(t *testing.T) {
-			asserter := helper.Asserter{T: t}
-			var stateMachine StateMachine
-			stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
-			stateMachine.stateMachineFlags.Until = tc.until
-			stateMachine.stateMachineFlags.Thru = tc.thru
-			stateMachine.stateMachineFlags.Resume = tc.resume
-
-			err := stateMachine.validateInput()
-			asserter.AssertErrContains(err, tc.errMsg)
-		})
-	}
-}
-
 // TestDebug ensures that the name of the states is printed when the --debug flag is used
 func TestDebug(t *testing.T) {
 	t.Run("test_debug", func(t *testing.T) {


### PR DESCRIPTION
While testing something I noticed a bug related to dynamically calculating states. We were previously checking the values of `--thru` and `--until` to make sure that the specified state was actually in the state machine. With the dynamic change, we were doing that before the state machine was assembled, which led to an error.

I fixed this by breaking out this check into a separate function and moving it to the appropriate place for each state machine type. In the snap state machines that is in the Setup() function. In the classic state machines it is at the end of the calculateStates() function.