### PR TITLE
Initialize an empty content if system-data or system-seed doesn't have one defined

### DIFF
--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -239,6 +239,14 @@ func (stateMachine *StateMachine) postProcessGadgetYaml() error {
 			lastOffset = offset + quantity.Offset(structure.Size)
 			farthestOffset = maxOffset(lastOffset, farthestOffset)
 			structure.Offset = &offset
+
+			// system-data and system-seed do not always have content defined.
+			// this makes Content be a nil slice and lead copyStructureContent() skip the rootfs copying later.
+			// so we need to make an empty slice here to avoid this situation.
+			if (structure.Role == gadget.SystemData || structure.Role == gadget.SystemSeed) && structure.Content == nil {
+				structure.Content = make([]gadget.VolumeContent, 0)
+			}
+
 			// we've manually updated the offset, but since structure is
 			// not a pointer we need to overwrite the value in volume.Structure
 			volume.Structure[ii] = structure


### PR DESCRIPTION
When using ubuntu-image 2.2+snap9 (and snap10), I found that the root filesystem wasn't copied to the `system-data` or `system-seed` partition.
After debugging, I realized that `copyStructureContent()` [[link](https://github.com/canonical/ubuntu-image/blob/f279cd24e863aea43174a290c76aac86ec45b429/internal/statemachine/helper.go#L220)] skipped the copy because there was no partition content  defined in the `system-seed` of the `gadget.yaml`.

The reasons that the generic gadget snaps don't have this issue are:
* Ubuntu Core PC and Pi gadget snaps, they have bootloader files[[link-pc](https://github.com/snapcore/pc-amd64-gadget/blob/fe5397fa1cf9e1ec8ca83a20e3ca4b599765f7dd/gadget.yaml#L30)] [[link-pi](https://github.com/snapcore/pi-gadget/blob/fc26d766e640ea8e54883337a6e1d49f828cec00/gadget.yaml#L11)].
* Ubuntu Classic PC gadget snap, it doesn't have the `system-data` partition defined [[link](https://github.com/snapcore/pc-amd64-gadget/blob/classic/gadget.yaml)] and `postProcessGadgetYaml()` [[link](https://github.com/canonical/ubuntu-image/blob/f279cd24e863aea43174a290c76aac86ec45b429/internal/statemachine/state_machine.go#L264)] will initialize a partition with an empty `Content`.

However, the `system-data` and `system-seed` do not always have additional content besides the root filesystem. My PR is to check the `structure.Content` in `postProcessGadgetYaml()` and if it's a nil slice then create an empty one.

Another way is check `Role` before mkfs and copying in `copyStructureContent()` of `helper.go` and always use `mkfsMakeWithContent()` for system-seed and system-data. For [example](https://github.com/tsunghanliu/ubuntu-image/commit/45570731351b18a11320d8683bf7cd057d36e791):
```patch
diff --git a/internal/statemachine/helper.go b/internal/statemachine/helper.go
index c22bcce..fca2048 100644
--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -217,7 +217,7 @@ func (stateMachine *StateMachine) copyStructureContent(volume *gadget.Volume,
 			}
 		}
 		// use mkfs functions from snapd to create the filesystems
-		if structure.Content == nil {
+		if structure.Content == nil && structure.Role != gadget.SystemData && structure.Role != gadget.SystemSeed {
 			err := mkfsMake(structure.Filesystem, partImg, structure.Label,
 				structure.Size, stateMachine.SectorSize)
 			if err != nil {
```
But I think the PR way is easier for understand and consistent.