### PR TITLE
Fix issue with partitions not being sized properly

### DIFF
--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -86,3 +86,11 @@ func CopyBlob(ddArgs []string) error {
 	}
 	return nil
 }
+
+// SafeQuantitySubtraction subtracts quantities while checking for integer underflow
+func SafeQuantitySubtraction(orig, subtract quantity.Size) quantity.Size {
+	if subtract > orig {
+		return 0
+	}
+	return orig - subtract
+}

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -333,22 +333,27 @@ func TestFailedGenerateDiskInfo(t *testing.T) {
 	})
 }
 
-// TestCalculateRootfsSize tests that the rootfs size can be calculated
+// TestCalculateRootfsSizeNoImageSize tests that the rootfs size can be
+// calculated by using du commands when the image size is not specified
 // this is accomplished by setting the test gadget tree as rootfs and
 // verifying that the size is calculated correctly
-func TestCalculateRootfsSize(t *testing.T) {
-	t.Run("test_calculate_rootfs_size", func(t *testing.T) {
+func TestCalculateRootfsSizeNoImageSize(t *testing.T) {
+	t.Run("test_calculate_rootfs_size_no_image_size", func(t *testing.T) {
 		asserter := helper.Asserter{T: t}
 		var stateMachine StateMachine
 		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 		stateMachine.tempDirs.rootfs = filepath.Join("testdata", "gadget_tree")
+
+		// need workdir set up for this
+		err := stateMachine.makeTemporaryDirectories()
+		asserter.AssertErrNil(err, true)
 
 		// set a valid yaml file and load it in
 		stateMachine.YamlFilePath = filepath.Join("testdata",
 			"gadget_tree", "meta", "gadget.yaml")
 		// ensure unpack exists
 		os.MkdirAll(filepath.Join(stateMachine.tempDirs.unpack, "gadget"), 0755)
-		err := stateMachine.loadGadgetYaml()
+		err = stateMachine.loadGadgetYaml()
 		asserter.AssertErrNil(err, true)
 
 		err = stateMachine.calculateRootfsSize()
@@ -367,6 +372,50 @@ func TestCalculateRootfsSize(t *testing.T) {
 
 		os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
 	})
+}
+
+// TestCalculateRootfsSizeImageSize tests that the rootfs size can be
+// accurately calculated when the image size is specified
+func TestCalculateRootfsSizeImageSize(t *testing.T) {
+	testCases := []struct {
+		name         string
+		sizeArg      string
+		expectedSize quantity.Size
+	}{
+		{"one_image_size", "4G", 4183818240},
+		{"image_size_per_volume", "pc:4G", 4183818240},
+	}
+	for _, tc := range testCases {
+		t.Run("test_calculate_rootfs_size_image_size", func(t *testing.T) {
+			asserter := helper.Asserter{T: t}
+			var stateMachine StateMachine
+			stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+			stateMachine.tempDirs.rootfs = filepath.Join("testdata", "gadget_tree")
+			stateMachine.commonFlags.Size = tc.sizeArg
+
+			// need workdir set up for this
+			err := stateMachine.makeTemporaryDirectories()
+			asserter.AssertErrNil(err, true)
+
+			// set a valid yaml file and load it in
+			stateMachine.YamlFilePath = filepath.Join("testdata",
+				"gadget_tree", "meta", "gadget.yaml")
+			// ensure unpack exists
+			os.MkdirAll(filepath.Join(stateMachine.tempDirs.unpack, "gadget"), 0755)
+			err = stateMachine.loadGadgetYaml()
+			asserter.AssertErrNil(err, true)
+
+			err = stateMachine.calculateRootfsSize()
+			asserter.AssertErrNil(err, true)
+
+			if stateMachine.RootfsSize != tc.expectedSize {
+				t.Errorf("Expected rootfs size %d, but got %d",
+					tc.expectedSize, stateMachine.RootfsSize)
+			}
+
+			os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
+		})
+	}
 }
 
 // TestFailedCalculateRootfsSize tests a failure when calculating the rootfs size
@@ -1028,19 +1077,15 @@ func TestImageSizeFlag(t *testing.T) {
 			//defer os.RemoveAll(outDir)
 			stateMachine.commonFlags.OutputDir = outDir
 
+			// set up a "rootfs" that we can eventually copy into the disk
+			os.MkdirAll(stateMachine.tempDirs.rootfs, 0755)
+			osutil.CopySpecialFile(tc.gadgetTree, stateMachine.tempDirs.rootfs)
+
 			// set a valid yaml file and load it in
 			stateMachine.YamlFilePath = filepath.Join(tc.gadgetTree, "meta", "gadget.yaml")
 			// ensure unpack exists
 			os.MkdirAll(filepath.Join(stateMachine.tempDirs.unpack, "gadget"), 0755)
 			err = stateMachine.loadGadgetYaml()
-			asserter.AssertErrNil(err, true)
-
-			// set up a "rootfs" that we can eventually copy into the disk
-			os.MkdirAll(stateMachine.tempDirs.rootfs, 0755)
-			osutil.CopySpecialFile(tc.gadgetTree, stateMachine.tempDirs.rootfs)
-
-			// also need to set the rootfs size to avoid partition errors
-			err = stateMachine.calculateRootfsSize()
 			asserter.AssertErrNil(err, true)
 
 			// ensure volumes exists
@@ -1052,6 +1097,10 @@ func TestImageSizeFlag(t *testing.T) {
 				srcFile := filepath.Join(tc.gadgetTree, srcFile.Name())
 				osutil.CopySpecialFile(srcFile, filepath.Join(stateMachine.tempDirs.unpack, "gadget"))
 			}
+
+			// also need to set the rootfs size to avoid partition errors
+			err = stateMachine.calculateRootfsSize()
+			asserter.AssertErrNil(err, true)
 
 			// run through the rest of the states
 			err = stateMachine.populateBootfsContents()

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -216,18 +216,24 @@ func (stateMachine *StateMachine) copyStructureContent(volume *gadget.Volume,
 					partImg, err.Error())
 			}
 		}
+		// check if any content exists in unpack
+		contentFiles, err := ioutilReadDir(contentRoot)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("Error listing contents of volume \"%s\": %s",
+				contentRoot, err.Error())
+		}
 		// use mkfs functions from snapd to create the filesystems
-		if structure.Content == nil {
-			err := mkfsMake(structure.Filesystem, partImg, structure.Label,
-				structure.Size, stateMachine.SectorSize)
-			if err != nil {
-				return fmt.Errorf("Error running mkfs: %s", err.Error())
-			}
-		} else {
+		if structure.Content != nil || len(contentFiles) > 0 {
 			err := mkfsMakeWithContent(structure.Filesystem, partImg, structure.Label,
 				contentRoot, structure.Size, stateMachine.SectorSize)
 			if err != nil {
 				return fmt.Errorf("Error running mkfs with content: %s", err.Error())
+			}
+		} else {
+			err := mkfsMake(structure.Filesystem, partImg, structure.Label,
+				structure.Size, stateMachine.SectorSize)
+			if err != nil {
+				return fmt.Errorf("Error running mkfs: %s", err.Error())
 			}
 		}
 	}

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -344,7 +344,7 @@ func (stateMachine *StateMachine) handleContentSizes(farthestOffset quantity.Off
 	} else {
 		if volumeSize < calculated {
 			fmt.Printf("WARNING: ignoring image size smaller than "+
-				"minimum required size: vol:%s %d < %d",
+				"minimum required size: vol:%s %d < %d\n",
 				volumeName, uint64(volumeSize), uint64(calculated))
 			stateMachine.ImageSizes[volumeName] = calculated
 		} else {

--- a/internal/statemachine/testdata/gadget-no-content.yaml
+++ b/internal/statemachine/testdata/gadget-no-content.yaml
@@ -1,0 +1,21 @@
+volumes:
+  pc:
+    bootloader: grub
+    structure:
+      - name: mbr
+        type: mbr
+        size: 440
+        content:
+          - image: pc-boot.img
+      - name: BIOS Boot
+        type: DA,21686148-6449-6E6F-744E-656564454649
+        size: 1M
+        offset: 1M
+        offset-write: mbr+92
+        content:
+          - image: pc-core.img
+      - name: system-boot
+        type: 0C,EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
+        filesystem: vfat
+        filesystem-label: system-boot
+        size: 50M


### PR DESCRIPTION
There was an issue reported yesterday about partitions not being the correct size: https://bugs.launchpad.net/ubuntu-image/+bug/1981744

This seems to come from a difference in the behavior of go-diskfs and the python `parted` library. While the images are the correct size, the partition table is not being written in a way that fills the disk.

My strategy to address this was as follows: If `--image-size` is specified, instead of using `du` to determine the size of the rootfs, instead calculate the rootfs size as `<total_image_size> - (sum(<all other partition sizes + offsets>))`

This has the effect that if an image size of `3G` is specified and the total space taken up by other partitions is `1G`, the rootfs will be created with `2G` of space. This increased size is passed directly to go-diskfs, and the partitions actually fill the whole disk now.