### PR TITLE
snapcraft.yaml: Set environment to load the correct gconv modules

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,6 +14,7 @@ issues: https://bugs.launchpad.net/ubuntu-image/+filebug
 environment:
   FAKEROOT_FLAGS: "--lib $SNAP/usr/lib/lib-arch/libfakeroot/libfakeroot-tcp.so --faked $SNAP/usr/bin/faked-tcp"
   PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/sbin:$PATH
+  GCONV_PATH: /snap/core20/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gconv
 
 apps:
   ubuntu-image:


### PR DESCRIPTION
glibc from core20 is loaded by mtools. And since mtools uses glibc to
do encoding conversion, it needs to load gconv modules. The gconv
modules from host might be incompatible with the version of
glibc in core20. So GCONV_PATH has to be set to load the
modules from core20.

This work-around can be removed once the snap is properly confined.

Fixes https://bugs.launchpad.net/ubuntu-image/+bug/1814762