### PR TITLE
Sanitize the paths on our manual customization paths

### DIFF
--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -247,13 +247,14 @@ func TestPrintStates(t *testing.T) {
 [6] preseed_image
 [7] populate_rootfs_contents
 [8] customize_cloud_init
-[9] generate_disk_info
-[10] calculate_rootfs_size
-[11] populate_bootfs_contents
-[12] populate_prepare_partitions
-[13] make_disk
-[14] generate_manifest
-[15] finish
+[9] perform_manual_customization
+[10] generate_disk_info
+[11] calculate_rootfs_size
+[12] populate_bootfs_contents
+[13] populate_prepare_partitions
+[14] make_disk
+[15] generate_manifest
+[16] finish
 `
 		if !strings.Contains(string(readStdout), expectedStates) {
 			t.Errorf("Expected states to be printed in output:\n\"%s\"\n but got \n\"%s\"\n instead",

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -60,6 +60,10 @@ func TestYAMLSchemaParsing(t *testing.T) {
 		{"not_valid_yaml", "test_invalid_yaml.yaml", false, "yaml: unmarshal errors"},
 		{"missing_yaml_fields", "test_missing_name.yaml", false, "Key \"name\" is required in struct \"ImageDefinition\", but is not in the YAML file!"},
 		{"private_ppa_without_fingerprint", "test_private_ppa_without_fingerprint.yaml", false, "Fingerprint is required for private PPAs"},
+		{"invalid_paths_in_manual_copy", "test_invalid_paths_in_manual_copy.yaml", false, "needs to be an absolute path (../../malicious)"},
+		{"invalid_paths_in_manual_copy_bug", "test_invalid_paths_in_manual_copy.yaml", false, "needs to be an absolute path (/../../malicious)"},
+		{"invalid_paths_in_manual_touch_file", "test_invalid_paths_in_manual_touch_file.yaml", false, "needs to be an absolute path (../../malicious)"},
+		{"invalid_paths_in_manual_touch_file_bug", "test_invalid_paths_in_manual_touch_file.yaml", false, "needs to be an absolute path (/../../malicious)"},
 	}
 	for _, tc := range testCases {
 		t.Run("test_yaml_schema_"+tc.name, func(t *testing.T) {

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -795,7 +795,7 @@ func manualCopyFile(copyFileInterfaces interface{}, targetDir string, debug bool
 		}
 		absDest, _ := filepath.Abs(dest)
 		if !strings.HasPrefix(absDest, targetDir) {
-			return fmt.Errorf("Error copying file \"%s\" into chroot: destination outside of chroot (\"%s\")",
+			return fmt.Errorf("Invalid copy path \"%s\": destination outside of chroot (\"%s\")",
 				copyFile.Source, absDest)
 		}
 		if err := osutilCopySpecialFile(copyFile.Source, dest); err != nil {
@@ -836,7 +836,7 @@ func manualTouchFile(touchFileInterfaces interface{}, targetDir string, debug bo
 		}
 		absDest, _ := filepath.Abs(fullPath)
 		if !strings.HasPrefix(absDest, targetDir) {
-			return fmt.Errorf("Error creating file in chroot: destination outside of chroot (\"%s\")",
+			return fmt.Errorf("Invalid touch path: destination outside of chroot (\"%s\")",
 				absDest)
 		}
 		_, err := osCreate(fullPath)

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -793,11 +793,6 @@ func manualCopyFile(copyFileInterfaces interface{}, targetDir string, debug bool
 		if debug {
 			fmt.Printf("Copying file \"%s\" to \"%s\"", copyFile.Source, dest)
 		}
-		absDest, _ := filepath.Abs(dest)
-		if !strings.HasPrefix(absDest, targetDir) {
-			return fmt.Errorf("Invalid copy path \"%s\": destination outside of chroot (\"%s\")",
-				copyFile.Source, absDest)
-		}
 		if err := osutilCopySpecialFile(copyFile.Source, dest); err != nil {
 			return fmt.Errorf("Error copying file \"%s\" into chroot: %s",
 				copyFile.Source, err.Error())
@@ -833,11 +828,6 @@ func manualTouchFile(touchFileInterfaces interface{}, targetDir string, debug bo
 		fullPath := filepath.Join(targetDir, touchFile.TouchPath)
 		if debug {
 			fmt.Printf("Creating empty file \"%s\"", fullPath)
-		}
-		absDest, _ := filepath.Abs(fullPath)
-		if !strings.HasPrefix(absDest, targetDir) {
-			return fmt.Errorf("Invalid touch path: destination outside of chroot (\"%s\")",
-				absDest)
 		}
 		_, err := osCreate(fullPath)
 		if err != nil {

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -793,6 +793,11 @@ func manualCopyFile(copyFileInterfaces interface{}, targetDir string, debug bool
 		if debug {
 			fmt.Printf("Copying file \"%s\" to \"%s\"", copyFile.Source, dest)
 		}
+		absDest, _ := filepath.Abs(dest)
+		if !strings.HasPrefix(absDest, targetDir) {
+			return fmt.Errorf("Error copying file \"%s\" into chroot: destination outside of chroot (\"%s\")",
+				copyFile.Source, absDest)
+		}
 		if err := osutilCopySpecialFile(copyFile.Source, dest); err != nil {
 			return fmt.Errorf("Error copying file \"%s\" into chroot: %s",
 				copyFile.Source, err.Error())
@@ -828,6 +833,11 @@ func manualTouchFile(touchFileInterfaces interface{}, targetDir string, debug bo
 		fullPath := filepath.Join(targetDir, touchFile.TouchPath)
 		if debug {
 			fmt.Printf("Creating empty file \"%s\"", fullPath)
+		}
+		absDest, _ := filepath.Abs(fullPath)
+		if !strings.HasPrefix(absDest, targetDir) {
+			return fmt.Errorf("Error creating file in chroot: destination outside of chroot (\"%s\")",
+				absDest)
 		}
 		_, err := osCreate(fullPath)
 		if err != nil {

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -775,7 +775,7 @@ func TestFailedManualCopyFile(t *testing.T) {
 				Source: "/test/does/not/exist",
 			},
 		}
-		err := manualCopyFile(copyFiles, "fakedir", true)
+		err := manualCopyFile(copyFiles, "/fakedir", true)
 		asserter.AssertErrContains(err, "Error copying file")
 	})
 }

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -806,7 +806,7 @@ func TestFailedManualTouchFile(t *testing.T) {
 				TouchPath: "/test/does/not/exist",
 			},
 		}
-		err := manualTouchFile(touchFiles, "fakedir", true)
+		err := manualTouchFile(touchFiles, "/fakedir", true)
 		asserter.AssertErrContains(err, "Error creating file")
 	})
 }

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -780,22 +780,6 @@ func TestFailedManualCopyFile(t *testing.T) {
 	})
 }
 
-// TestWrongPathManualCopyFile tests for failures on destination outside of the chroot
-func TestWrongPathManualCopyFile(t *testing.T) {
-	t.Run("test_wrong_path_manual_copy_file", func(t *testing.T) {
-		asserter := helper.Asserter{T: t}
-
-		copyFiles := []*CopyFileType{
-			{
-				Dest:   "../etc/shadow",
-				Source: "/test/does/not/exist",
-			},
-		}
-		err := manualCopyFile(copyFiles, "/fakedir", true)
-		asserter.AssertErrContains(err, "destination outside of chroot")
-	})
-}
-
 // TestFailedManualTouchFile tests the fail case of the manualTouchFile function
 func TestFailedManualTouchFile(t *testing.T) {
 	t.Run("test_failed_manual_touch_file", func(t *testing.T) {
@@ -808,21 +792,6 @@ func TestFailedManualTouchFile(t *testing.T) {
 		}
 		err := manualTouchFile(touchFiles, "/fakedir", true)
 		asserter.AssertErrContains(err, "Error creating file")
-	})
-}
-
-// TestWrongPathManualTouchFile tests for failures on touch-path outside of the chroot
-func TestWrongPathManualTouchFile(t *testing.T) {
-	t.Run("test_wrong_path_manual_touch_file", func(t *testing.T) {
-		asserter := helper.Asserter{T: t}
-
-		touchFiles := []*TouchFileType{
-			{
-				TouchPath: "../etc/malicious-file",
-			},
-		}
-		err := manualTouchFile(touchFiles, "/fakedir", true)
-		asserter.AssertErrContains(err, "destination outside of chroot")
 	})
 }
 

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -780,6 +780,22 @@ func TestFailedManualCopyFile(t *testing.T) {
 	})
 }
 
+// TestWrongPathManualCopyFile tests for failures on destination outside of the chroot
+func TestWrongPathManualCopyFile(t *testing.T) {
+	t.Run("test_wrong_path_manual_copy_file", func(t *testing.T) {
+		asserter := helper.Asserter{T: t}
+
+		copyFiles := []*CopyFileType{
+			{
+				Dest:   "../etc/shadow",
+				Source: "/test/does/not/exist",
+			},
+		}
+		err := manualCopyFile(copyFiles, "/fakedir", true)
+		asserter.AssertErrContains(err, "destination outside of chroot")
+	})
+}
+
 // TestFailedManualTouchFile tests the fail case of the manualTouchFile function
 func TestFailedManualTouchFile(t *testing.T) {
 	t.Run("test_failed_manual_touch_file", func(t *testing.T) {
@@ -792,6 +808,21 @@ func TestFailedManualTouchFile(t *testing.T) {
 		}
 		err := manualTouchFile(touchFiles, "fakedir", true)
 		asserter.AssertErrContains(err, "Error creating file")
+	})
+}
+
+// TestWrongPathManualTouchFile tests for failures on touch-path outside of the chroot
+func TestWrongPathManualTouchFile(t *testing.T) {
+	t.Run("test_wrong_path_manual_touch_file", func(t *testing.T) {
+		asserter := helper.Asserter{T: t}
+
+		touchFiles := []*TouchFileType{
+			{
+				TouchPath: "../etc/malicious-file",
+			},
+		}
+		err := manualTouchFile(touchFiles, "/fakedir", true)
+		asserter.AssertErrContains(err, "destination outside of chroot")
 	})
 }
 

--- a/internal/statemachine/image_definition.go
+++ b/internal/statemachine/image_definition.go
@@ -238,6 +238,23 @@ type InvalidPPAError struct {
 	gojsonschema.ResultErrorFields
 }
 
+func newPathNotAbsoluteError(context *gojsonschema.JsonContext, value interface{}, details gojsonschema.ErrorDetails) *PathNotAbsoluteError {
+	err := PathNotAbsoluteError{}
+	err.SetContext(context)
+	err.SetType("path_not_absolute_error")
+	err.SetDescriptionFormat("Key {{.key}} needs to be an absolute path ({{.value}})")
+	err.SetValue(value)
+	err.SetDetails(details)
+
+	return &err
+}
+
+// PathNotAbsoluteError implements gojsonschema.ErrorType. It is used for custom errors for
+// fields that should be absolute but are not
+type PathNotAbsoluteError struct {
+	gojsonschema.ResultErrorFields
+}
+
 // generatePocketList returns a slice of strings that need to be added to
 // /etc/apt/sources.list in the chroot based on the value of "pocket"
 // in the rootfs section of the image definition

--- a/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_copy.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_copy.yaml
@@ -38,11 +38,11 @@ customization:
   manual:
     copy-file:
       -
-        source: /etc/hosts
-        destination: /etc/hosts
-    touch-file:
+        source: /foo/bar
+        destination: /../../malicious
       -
-        path: /etc/foo
+        source: /foo/bar
+        destination: ../../malicious
 artifacts:
   img:
       path: raspi.img

--- a/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_touch_file.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_touch_file.yaml
@@ -36,13 +36,11 @@ customization:
     - name: linux-firmware-raspi
     - name: pi-bluetooth
   manual:
-    copy-file:
-      -
-        source: /etc/hosts
-        destination: /etc/hosts
     touch-file:
       -
-        path: /etc/foo
+        path: ../../malicious
+      -
+        path: /../../malicious
 artifacts:
   img:
       path: raspi.img


### PR DESCRIPTION
We need to do this as otherwise someone can use ubuntu-image in a malicious way. Without checking for the paths, someone could craft a malicious image-definition file, send it over to others and then cause harm to their build host machines as ubuntu-image requires root access. Like, someone could copy over some weird files around the host filesystem.
I think such a check should be sufficient, but I feel like at some moment in the future we might want to get the security team taking a look at the code to see if there's no other potential attack vectors.