### PR TITLE
FR-2622 customize /etc/fstab

### DIFF
--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -172,6 +172,10 @@ func (stateMachine *StateMachine) calculateStates() error {
 		rootfsCreationStates = append(rootfsCreationStates,
 			stateFunc{"customize_cloud_init", (*StateMachine).customizeCloudInit})
 	}
+	if len(classicStateMachine.ImageDef.Customization.Fstab) > 0 {
+		rootfsCreationStates = append(rootfsCreationStates,
+			stateFunc{"customize_fstab", (*StateMachine).customizeFstab})
+	}
 	if classicStateMachine.ImageDef.Customization.Manual != nil {
 		rootfsCreationStates = append(rootfsCreationStates,
 			stateFunc{"perform_manual_customization", (*StateMachine).manualCustomization})
@@ -495,6 +499,41 @@ func (stateMachine *StateMachine) setupExtraPPAs() error {
 // but what about extra packages with a tarball based images...
 func (stateMachine *StateMachine) installExtraPackages() error {
 	// currently a no-op pending implementation of the classic image redesign
+	return nil
+}
+
+// Customize /etc/fstab based on values in the image definition
+func (stateMachine *StateMachine) customizeFstab() error {
+	var classicStateMachine *ClassicStateMachine
+	classicStateMachine = stateMachine.parent.(*ClassicStateMachine)
+
+	// open /etc/fstab for writing
+	fstabIO, err := osOpenFile(filepath.Join(stateMachine.tempDirs.chroot, "etc", "fstab"),
+		os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("Error opening fstab: %s", err.Error())
+	}
+	defer fstabIO.Close()
+
+	var fstabEntries []string
+	for _, fstab := range classicStateMachine.ImageDef.Customization.Fstab {
+		var dumpString string
+		if fstab.Dump {
+			dumpString = "1"
+		} else {
+			dumpString = "0"
+		}
+		fstabEntry := fmt.Sprintf("LABEL=%s\t%s\t%s\t%s\t%s\t%d",
+			fstab.Label,
+			fstab.Mountpoint,
+			fstab.FSType,
+			fstab.MountOptions,
+			dumpString,
+			fstab.FsckOrder,
+		)
+		fstabEntries = append(fstabEntries, fstabEntry)
+	}
+	fstabIO.Write([]byte(strings.Join(fstabEntries, "\n")))
 	return nil
 }
 

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -1483,7 +1483,7 @@ func TestCustomizeFstab(t *testing.T) {
 		{
 			"one_entry",
 			[]*FstabType{
-				&FstabType{
+				{
 					Label:        "writable",
 					Mountpoint:   "/",
 					FSType:       "ext4",
@@ -1497,7 +1497,7 @@ func TestCustomizeFstab(t *testing.T) {
 		{
 			"two_entries",
 			[]*FstabType{
-				&FstabType{
+				{
 					Label:        "writable",
 					Mountpoint:   "/",
 					FSType:       "ext4",
@@ -1505,7 +1505,7 @@ func TestCustomizeFstab(t *testing.T) {
 					Dump:         false,
 					FsckOrder:    1,
 				},
-				&FstabType{
+				{
 					Label:        "system-boot",
 					Mountpoint:   "/boot/firmware",
 					FSType:       "vfat",
@@ -1520,7 +1520,7 @@ LABEL=system-boot	/boot/firmware	vfat	defaults	0	1`,
 		{
 			"defaults_assumed",
 			[]*FstabType{
-				&FstabType{
+				{
 					Label:      "writable",
 					Mountpoint: "/",
 					FSType:     "ext4",
@@ -1594,7 +1594,7 @@ func TestFailedCustomizeFstab(t *testing.T) {
 			Rootfs:       &RootfsType{},
 			Customization: &CustomizationType{
 				Fstab: []*FstabType{
-					&FstabType{
+					{
 						Label:        "writable",
 						Mountpoint:   "/",
 						FSType:       "ext4",

--- a/internal/statemachine/image_definition.go
+++ b/internal/statemachine/image_definition.go
@@ -74,6 +74,7 @@ type CustomizationType struct {
 	ExtraPPAs     []*PPAType     `yaml:"extra-ppas"     json:"ExtraPPAs,omitempty"`
 	ExtraPackages []*PackageType `yaml:"extra-packages" json:"ExtraPackages,omitempty"`
 	ExtraSnaps    []*SnapType    `yaml:"extra-snaps"    json:"ExtraSnaps,omitempty"`
+	Fstab         []*FstabType   `yaml:"fstab"          json:"Fstab,omitempty"`
 	Manual        *ManualType    `yaml:"manual"         json:"Manual,omitempty"`
 }
 
@@ -115,6 +116,16 @@ type SnapType struct {
 	SnapRevision string `yaml:"revision" json:"SnapRevision,omitempty"`
 	Store        string `yaml:"store"    json:"Store"                  default:"canonical"`
 	Channel      string `yaml:"channel"  json:"Channel"                default:"stable"`
+}
+
+// FstabType defines the information that gets rendered into an fstab
+type FstabType struct {
+	Label        string `yaml:"label"           json:"Label"`
+	Mountpoint   string `yaml:"mountpoint"      json:"Mountpoint"`
+	FSType       string `yaml:"filesystem-type" json:"FSType"`
+	MountOptions string `yaml:"mount-options"   json:"MountOptions" default:"defaults"`
+	Dump         bool   `yaml:"dump"            json:"Dump,omitempty"`
+	FsckOrder    int    `yaml:"fsck-order" json:"FsckOrder"`
 }
 
 // ManualType provides manual customization options

--- a/internal/statemachine/image_definition.go
+++ b/internal/statemachine/image_definition.go
@@ -254,13 +254,13 @@ type InvalidPPAError struct {
 // in the rootfs section of the image definition
 func (ImageDef ImageDefinition) generatePocketList() []string {
 	pocketMap := map[string][]string{
-		"release": []string{},
-		"security": []string{
+		"release": {},
+		"security": {
 			fmt.Sprintf("deb http://security.ubuntu.com/ubuntu/ %s-security %s\n",
 				ImageDef.Series, strings.Join(ImageDef.Rootfs.Components, " "),
 			),
 		},
-		"updates": []string{
+		"updates": {
 			fmt.Sprintf("deb http://archive.ubuntu.com/ubuntu/ %s-updates %s\n",
 				ImageDef.Series, strings.Join(ImageDef.Rootfs.Components, " "),
 			),
@@ -268,7 +268,7 @@ func (ImageDef ImageDefinition) generatePocketList() []string {
 				ImageDef.Series, strings.Join(ImageDef.Rootfs.Components, " "),
 			),
 		},
-		"proposed": []string{
+		"proposed": {
 			fmt.Sprintf("deb http://archive.ubuntu.com/ubuntu/ %s-updates %s\n",
 				ImageDef.Series, strings.Join(ImageDef.Rootfs.Components, " "),
 			),

--- a/internal/statemachine/image_definition.go
+++ b/internal/statemachine/image_definition.go
@@ -125,7 +125,7 @@ type FstabType struct {
 	FSType       string `yaml:"filesystem-type" json:"FSType"`
 	MountOptions string `yaml:"mount-options"   json:"MountOptions" default:"defaults"`
 	Dump         bool   `yaml:"dump"            json:"Dump,omitempty"`
-	FsckOrder    int    `yaml:"fsck-order" json:"FsckOrder"`
+	FsckOrder    int    `yaml:"fsck-order"      json:"FsckOrder"`
 }
 
 // ManualType provides manual customization options

--- a/internal/statemachine/testdata/image_definitions/test_valid.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_valid.yaml
@@ -35,6 +35,20 @@ customization:
     - name: ubuntu-minimal
     - name: linux-firmware-raspi
     - name: pi-bluetooth
+  fstab:
+    -
+      label: "writable"
+      mountpoint: "/"
+      filesystem-type: "ext4"
+      dump: false
+      fsck-order: 1
+    -
+      label: "system-boot"
+      mountpoint: "/boot/firmware"
+      filesystem-type: "vfat"
+      mount-options: "defaults"
+      dump: false
+      fsck-order: 1
 artifacts:
   img:
       path: raspi.img


### PR DESCRIPTION
This PR adds a new fstab section to the customization section of the image definition, and populates the contents of /etc/fstab in the chroot based on the image definition.