### PR TITLE
implement customizeCloudInit for classic images

### DIFF
--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -17,6 +17,7 @@ import (
 	"github.com/invopop/jsonschema"
 	"github.com/snapcore/snapd/image"
 	"github.com/snapcore/snapd/osutil"
+
 	//"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
@@ -542,23 +543,16 @@ func (stateMachine *StateMachine) germinate() error {
 func (stateMachine *StateMachine) customizeCloudInit() error {
 	classicStateMachine := stateMachine.parent.(*ClassicStateMachine)
 
-	if customization := classicStateMachine.ImageDef.Customization; customization == nil || customization.CloudInit == nil {
-		if stateMachine.commonFlags.Debug {
-			fmt.Println("no cloud-init config found")
-		}
-		return nil
-	}
-
 	cloudInitCustomization := classicStateMachine.ImageDef.Customization.CloudInit
 
 	seedPath := path.Join(classicStateMachine.tempDirs.chroot, "var/lib/cloud/seed/nocloud")
-	err := os.MkdirAll(seedPath, 0755)
+	err := osMkdirAll(seedPath, 0755)
 	if err != nil {
 		return err
 	}
 
 	if cloudInitCustomization.MetaData != "" {
-		metaDataFile, err := os.Create(path.Join(seedPath, "meta-data"))
+		metaDataFile, err := osCreate(path.Join(seedPath, "meta-data"))
 		if err != nil {
 			return err
 		}
@@ -571,7 +565,7 @@ func (stateMachine *StateMachine) customizeCloudInit() error {
 	}
 
 	if cloudInitCustomization.UserData != nil {
-		userDataFile, err := os.Create(path.Join(seedPath, "user-data"))
+		userDataFile, err := osCreate(path.Join(seedPath, "user-data"))
 		if err != nil {
 			return err
 		}
@@ -589,7 +583,7 @@ func (stateMachine *StateMachine) customizeCloudInit() error {
 	}
 
 	if cloudInitCustomization.NetworkConfig != "" {
-		networkConfigFile, err := os.Create(path.Join(seedPath, "network-config"))
+		networkConfigFile, err := osCreate(path.Join(seedPath, "network-config"))
 		if err != nil {
 			return err
 		}
@@ -604,7 +598,7 @@ func (stateMachine *StateMachine) customizeCloudInit() error {
 	datasourceConfig := "# to update this file, run dpkg-reconfigure cloud-init\ndatasource_list: [ NoCloud ]\n"
 
 	dpkgConfigPath := path.Join(classicStateMachine.tempDirs.chroot, "etc/cloud/cloud.cfg.d/90_dpkg.cfg")
-	dpkgConfigFile, err := os.Create(dpkgConfigPath)
+	dpkgConfigFile, err := osCreate(dpkgConfigPath)
 	if err != nil {
 		return err
 	}

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -571,7 +571,7 @@ func (stateMachine *StateMachine) customizeCloudInit() error {
 		}
 		defer userDataFile.Close()
 
-		userDataBytes, err := yaml.Marshal(cloudInitCustomization.UserData)
+		userDataBytes, err := yamlMarshal(cloudInitCustomization.UserData)
 		if err != nil {
 			return err
 		}

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -19,6 +20,8 @@ import (
 	"github.com/invopop/jsonschema"
 	"github.com/snapcore/snapd/image"
 	"github.com/snapcore/snapd/osutil"
+
+	//"github.com/snapcore/snapd/osutil"
 	//"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/store"
 	"github.com/xeipuuv/gojsonschema"
@@ -424,19 +427,113 @@ func TestExtractRootfsTar(t *testing.T) {
 
 // TestCustomizeCloudInit unit tests the customizeCloudInit function
 func TestCustomizeCloudInit(t *testing.T) {
-	t.Run("test_customize_cloud_init", func(t *testing.T) {
-		asserter := helper.Asserter{T: t}
-		saveCWD := helper.SaveCWD()
-		defer saveCWD()
+	cloudInitConfigs := []CloudInitType{
+		{
+			MetaData:      "foo: bar",
+			NetworkConfig: "foobar: foobar",
+			UserData: &[]UserDataType{
+				{UserName: "ubuntu", UserPassword: "ubuntu"},
+				{UserName: "john", UserPassword: "password"},
+			},
+		},
+		{
+			MetaData:      "foo: bar",
+			NetworkConfig: "foobar: foobar",
+			UserData:      nil,
+		},
+		{
+			NetworkConfig: "foobar: foobar",
+			UserData:      &[]UserDataType{},
+		},
+		{
+			UserData: &[]UserDataType{
+				{UserName: "ubuntu", UserPassword: "ubuntu"},
+				{UserName: "john", UserPassword: "password"},
+			},
+		},
+	}
 
-		var stateMachine ClassicStateMachine
-		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+	for _, cloudInitConfig := range cloudInitConfigs {
+		t.Run("test_customize_cloud_init", func(t *testing.T) {
+			// Test setup
+			asserter := helper.Asserter{T: t}
+			saveCWD := helper.SaveCWD()
+			defer saveCWD()
 
-		err := stateMachine.customizeCloudInit()
-		asserter.AssertErrNil(err, true)
+			var stateMachine ClassicStateMachine
+			stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+			stateMachine.parent = &stateMachine
+			tmpDir, err := os.MkdirTemp("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmpDir)
+			stateMachine.tempDirs.chroot = tmpDir
 
-		os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
-	})
+			// this directory is expected to be present as it is installed by cloud-init
+			os.MkdirAll(path.Join(tmpDir, "etc/cloud/cloud.cfg.d"), 0777)
+
+			stateMachine.ImageDef.Customization = &CustomizationType{
+				CloudInit: &cloudInitConfig,
+			}
+
+			// Running function to test
+			err = stateMachine.customizeCloudInit()
+			asserter.AssertErrNil(err, true)
+
+			// Validation
+			seedPath := path.Join(tmpDir, "var/lib/cloud/seed/nocloud")
+
+			metaDataFile, err := os.Open(path.Join(seedPath, "meta-data"))
+			if cloudInitConfig.MetaData != "" {
+				asserter.AssertErrNil(err, false)
+
+				metaDataFileContent, err := ioutil.ReadAll(metaDataFile)
+				asserter.AssertErrNil(err, false)
+
+				if string(metaDataFileContent[:]) != cloudInitConfig.MetaData {
+					t.Errorf("un-expected meta-data content found: expected:\n%v\ngot:%v", cloudInitConfig.MetaData, string(metaDataFileContent[:]))
+				}
+			} else {
+				asserter.AssertErrContains(err, "no such file or directory")
+			}
+
+			networkConfigFile, err := os.Open(path.Join(seedPath, "network-config"))
+			if cloudInitConfig.NetworkConfig != "" {
+				asserter.AssertErrNil(err, false)
+
+				networkConfigFileContent, err := ioutil.ReadAll(networkConfigFile)
+				asserter.AssertErrNil(err, false)
+				if string(networkConfigFileContent[:]) != cloudInitConfig.NetworkConfig {
+					t.Errorf("un-expected network-config found: expected:\n%v\ngot:%v", cloudInitConfig.NetworkConfig, string(networkConfigFileContent[:]))
+				}
+			} else {
+				asserter.AssertErrContains(err, "no such file or directory")
+			}
+
+			userDataFile, err := os.Open(path.Join(seedPath, "user-data"))
+			if cloudInitConfig.UserData != nil {
+				asserter.AssertErrNil(err, false)
+
+				userDataFileContent, err := ioutil.ReadAll(userDataFile)
+				asserter.AssertErrNil(err, false)
+
+				userDataOut := make([]UserDataType, 0)
+				err = yaml.Unmarshal(userDataFileContent, &userDataOut)
+				asserter.AssertErrNil(err, false)
+
+				for i, user := range *cloudInitConfig.UserData {
+					if user != userDataOut[i] {
+						t.Errorf("expected user %#v got %#v", user, userDataOut[i])
+					}
+				}
+			} else {
+				asserter.AssertErrContains(err, "no such file or directory")
+			}
+
+			os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
+		})
+	}
 }
 
 // TestSetupExtraPPAs unit tests the setupExtraPPAs function

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -618,6 +618,27 @@ func TestFailedCustomizeCloudInit(t *testing.T) {
 		defer os.RemoveAll(cloudInitConfigDirPath)
 
 		osMkdirAll = mockMkdirAll
+		defer func() {
+			osMkdirAll = os.MkdirAll
+		}()
+
+		err := stateMachine.customizeCloudInit()
+		if err == nil {
+			t.Error()
+		}
+	})
+
+	// Test if yaml.Marshal fails
+	t.Run("Test_failed_customize_cloud_init_yaml_marshal", func(t *testing.T) {
+		// this directory is expected to be present as it is installed by cloud-init
+		cloudInitConfigDirPath := path.Join(tmpDir, "etc/cloud/cloud.cfg.d")
+		os.MkdirAll(cloudInitConfigDirPath, 0777)
+		defer os.RemoveAll(cloudInitConfigDirPath)
+
+		yamlMarshal = mockMarshal
+		defer func() {
+			yamlMarshal = yaml.Marshal
+		}()
 
 		err := stateMachine.customizeCloudInit()
 		if err == nil {

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -26,6 +26,8 @@ import (
 	"github.com/snapcore/snapd/osutil/mkfs"
 	"github.com/snapcore/snapd/seed"
 	"github.com/xeipuuv/gojsonschema"
+
+	"gopkg.in/yaml.v2"
 )
 
 // define some functions that can be mocked by test cases
@@ -58,6 +60,7 @@ var seedOpen = seed.Open
 var imagePrepare = image.Prepare
 var httpGet = http.Get
 var jsonUnmarshal = json.Unmarshal
+var yamlMarshal = yaml.Marshal
 var gojsonschemaValidate = gojsonschema.Validate
 
 var mockableBlockSize string = "1" //used for mocking dd calls

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -144,6 +144,9 @@ func mockGet(string) (*http.Response, error) {
 func mockUnmarshal([]byte, any) error {
 	return fmt.Errorf("Test Error")
 }
+func mockMarshal(interface{}) ([]byte, error) {
+	return []byte{}, fmt.Errorf("Test Error")
+}
 func mockGojsonschemaValidateError(gojsonschema.JSONLoader, gojsonschema.JSONLoader) (*gojsonschema.Result, error) {
 	return nil, fmt.Errorf("Test Error")
 }


### PR DESCRIPTION
If a cloud-init confguration is given (meta-data, user-data or
netowrk-config, it is writen in the chroot in
/var/lib/cloud/seed/nocloud. This is a supported (yet not documented)
way of configuring the NoCloud datasource.
The datasource list is set in /etc/cloud/cloud.cfg.d/90_dpkg.cfg to
NoCloud only.
This function get called only if a cloud-init config is present.