### PR TITLE
FR-2636 update to latest snapd version to support snapcraft v7 credentials (LP #1984014)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,12 @@ ubuntu-image (2.2+22.04ubuntu4) UNRELEASED; urgency=medium
   * Add support for uc20 preseeding-related options.
 
   [ William 'jawn-smith' Wilson ]
-  * Update to snapd 2.56
+  * Update to latest snapd that supports snapcraft v7 credentials
+    (LP: #1984014)
+  * Fix issue with partitions not being sized properly when using
+    --image-size (LP: #1981744)
+  * Create filesystems with content when the content was created by
+    ubuntu-image (LP: #1981720)
 
  -- William 'jawn-smith' Wilson <jawn-smith@ubuntu.com>  Wed, 08 Jun 2022 10:25:57 -0500
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/mvo5/goconfigparser v0.0.0-20201015074339-50f22f44deb5 // indirect
 	github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2 // indirect
-	github.com/snapcore/snapd v0.0.0-20220519134046-bb2af434538a
+	github.com/snapcore/snapd v0.0.0-20220826093156-687def3c41f1
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	gopkg.in/macaroon.v1 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2/go.mod h1:D3Ss
 github.com/snapcore/secboot v0.0.0-20211018143212-802bb19ca263 h1:cq2rG4JcNBCwHvo7iNdJL4nb8Ns7L/aOUd1EFs2toFs=
 github.com/snapcore/secboot v0.0.0-20211018143212-802bb19ca263/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
-github.com/snapcore/snapd v0.0.0-20220519134046-bb2af434538a h1:10n+WM5kRE2iGToI9uQkBh86QBRplEFfrXaSEZFb9TU=
-github.com/snapcore/snapd v0.0.0-20220519134046-bb2af434538a/go.mod h1:Ab4TsNgVast9nXAN8KVydI5G/hTHncgiQ4S1sAWjIXg=
+github.com/snapcore/snapd v0.0.0-20220826093156-687def3c41f1 h1:S/PgUzYBF+9u8BAz4HDPPOek57M2zgslcj8RqVK44ps=
+github.com/snapcore/snapd v0.0.0-20220826093156-687def3c41f1/go.mod h1:VJhUlHqGMBnSPFEKbJo2bTkiGjNvwF3nXRueCjgW05k=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -130,6 +130,10 @@ func (stateMachine *StateMachine) prepareClassicImage() error {
 		var imageOpts image.Options
 
 		var err error
+
+		// plug/slot sanitization not used by snap image.Prepare, make it no-op.
+		snap.SanitizePlugsSlots = func(snapInfo *snap.Info) {}
+
 		imageOpts.Snaps, imageOpts.SnapChannels, err = parseSnapsAndChannels(
 			classicStateMachine.commonFlags.Snaps)
 		if err != nil {
@@ -184,9 +188,6 @@ func (stateMachine *StateMachine) prepareClassicImage() error {
 
 		customizations := *new(image.Customizations)
 		imageOpts.Customizations = customizations
-
-		// plug/slot sanitization not used by snap image.Prepare, make it no-op.
-		snap.SanitizePlugsSlots = func(snapInfo *snap.Info) {}
 
 		if err := imagePrepare(&imageOpts); err != nil {
 			return fmt.Errorf("Error preparing image: %s", err.Error())


### PR DESCRIPTION
I was originally going to create a "TestLP1984014" to test this situation, but I decided not to for two reasons:

1. It would require exporting some credentials and then placing them here in GitHub
2. If snapcraft v8 or later changes authentication again this could end up being a moving target