### PR TITLE
Update link to gadget snap documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ course, you can just install the packages named in the `Build-Depends` field.
 * Manual page: man ubuntu-image
   (https://github.com/Canonical/ubuntu-image/blob/main/ubuntu-image.rst)
 
-The "gadget.yaml" specification has moved to [the snapcraft forum](https://forum.snapcraft.io/t/the-gadget-snap)
+The "gadget.yaml" specification has moved to [the snapcraft forum](https://forum.snapcraft.io/t/gadget-snaps)
 
 # Build Instructions
 


### PR DESCRIPTION
The old link seems to be dead, the new one points to the gadget snap documentation in the snapcraft discourse.