### PR TITLE
FR-2716 Miscellaneous cleanup

### DIFF
--- a/internal/imagedefinition/README.rst
+++ b/internal/imagedefinition/README.rst
@@ -25,9 +25,7 @@ The following specification defines what is supported in the YAML:
        # is just one kernel and defaults to "linux", but we support
        # installing more than one, since installer images can provide
        # multiple kernels to choose from.
-       kernel: (optional)
-         name: <string> Example: "linux" (required if kernel dict is specified)
-         type: <string> Example: "hwe" (optional)
+       kernel: <string> (optional)
        # gadget defines the boot assets of an image. When building a
        # classic image, the gadget is optionally compiled as part of
        # the state machine run.
@@ -372,15 +370,12 @@ kernel
 ======
 
 This optional key specifies an additional kernel to include in the image. If
-specified, the sub-key "name" must be provided, naming the kernel package to
-include. The sub-key "type" may be provided with a non-empty string value, but
-this is unused. For example:
+specified, the value should be a string that represents the name of the
+kernel package to be installed.
 
 .. code:: yaml
 
-    kernel:
-      name: linux
-      type: hwe
+    kernel: linux-image-generic
 
 
 

--- a/internal/imagedefinition/image_definition.go
+++ b/internal/imagedefinition/image_definition.go
@@ -19,19 +19,13 @@ type ImageDefinition struct {
 	Revision       int            `yaml:"revision"        json:"Revision,omitempty"`
 	Architecture   string         `yaml:"architecture"    json:"Architecture"`
 	Series         string         `yaml:"series"          json:"Series"`
-	Kernel         *Kernel        `yaml:"kernel"          json:"Kernel"`
+	Kernel         string         `yaml:"kernel"          json:"Kernel,omitempty"`
 	Gadget         *Gadget        `yaml:"gadget"          json:"Gadget"`
 	ModelAssertion string         `yaml:"model-assertion" json:"ModelAssertion,omitempty"`
 	Rootfs         *Rootfs        `yaml:"rootfs"          json:"Rootfs"`
 	Customization  *Customization `yaml:"customization"   json:"Customization,omitempty"`
 	Artifacts      *Artifact      `yaml:"artifacts"       json:"Artifacts"`
 	Class          string         `yaml:"class"           json:"Class" jsonschema:"enum=preinstalled,enum=cloud,enum=installer"`
-}
-
-// Kernel defines the kernel section of the image definition file
-type Kernel struct {
-	KernelName string `yaml:"name" json:"KernelName" default:"linux"`
-	KernelType string `yaml:"type" json:"KernelType,omitempty"`
 }
 
 // Gadget defines the gadget section of the image definition file
@@ -90,15 +84,9 @@ type Installer struct {
 
 // CloudInit provides customizations for running cloud-init
 type CloudInit struct {
-	MetaData      string      `yaml:"meta-data"      json:"MetaData,omitempty"`
-	UserData      *[]UserData `yaml:"user-data"      json:"UserData,omitempty"`
-	NetworkConfig string      `yaml:"network-config" json:"NetworkConfig,omitempty"`
-}
-
-// UserData defines the user information to be used by cloud-init
-type UserData struct {
-	UserName     string `yaml:"name"     json:"UserName"`
-	UserPassword string `yaml:"password" json:"UserPassword"`
+	MetaData      string `yaml:"meta-data"      json:"MetaData,omitempty"`
+	UserData      string `yaml:"user-data"      json:"UserData,omitempty"`
+	NetworkConfig string `yaml:"network-config" json:"NetworkConfig,omitempty"`
 }
 
 // PPA contains information about a public or private PPA

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -483,6 +483,12 @@ func (stateMachine *StateMachine) installPackages() error {
 		}
 	}
 
+	// Make sure to install the extra kernel if it is specified
+	if classicStateMachine.ImageDef.Kernel != "" {
+		classicStateMachine.Packages = append(classicStateMachine.Packages,
+			classicStateMachine.ImageDef.Kernel)
+	}
+
 	// Slice used to store all the commands that need to be run
 	// to install the packages
 	var installPackagesCmds []*exec.Cmd
@@ -630,19 +636,14 @@ func (stateMachine *StateMachine) customizeCloudInit() error {
 		}
 	}
 
-	if cloudInitCustomization.UserData != nil {
+	if cloudInitCustomization.UserData != "" {
 		userDataFile, err := osCreate(path.Join(seedPath, "user-data"))
 		if err != nil {
 			return err
 		}
 		defer userDataFile.Close()
 
-		userDataBytes, err := yamlMarshal(cloudInitCustomization.UserData)
-		if err != nil {
-			return err
-		}
-
-		_, err = userDataFile.Write(userDataBytes)
+		_, err = userDataFile.WriteString(cloudInitCustomization.UserData)
 		if err != nil {
 			return err
 		}

--- a/internal/statemachine/testdata/image_definitions/test_amd64.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_amd64.yaml
@@ -4,8 +4,7 @@ revision: 1
 architecture: amd64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux
+kernel: linux-image-generic
 gadget:
   url: "https://github.com/snapcore/pc-amd64-gadget.git"
   branch: classic
@@ -27,7 +26,7 @@ rootfs:
       - cloud-image
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_bad_class.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_bad_class.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: testclass
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
@@ -24,7 +23,7 @@ rootfs:
       - ubuntu-server-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_bad_ppa_name.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_bad_ppa_name.yaml
@@ -4,8 +4,7 @@ revision: 1
 architecture: amd64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux
+kernel: linux-image-generic
 gadget:
   url: "https://github.com/snapcore/pc-amd64-gadget.git"
   branch: classic
@@ -27,7 +26,7 @@ rootfs:
       - cloud-image
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_bad_url.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_bad_url.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "This is not a valid URL"
   branch: classic
@@ -23,7 +22,7 @@ rootfs:
       - ubuntu-server-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_both_seed_and_tasks.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_both_seed_and_tasks.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
@@ -27,7 +26,7 @@ rootfs:
     - desktop-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_build_gadget.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_build_gadget.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
@@ -24,7 +23,7 @@ rootfs:
       - ubuntu-server-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_customization.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_customization.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
@@ -24,7 +23,7 @@ rootfs:
       - ubuntu-server-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_extract_rootfs_tar.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_extract_rootfs_tar.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
@@ -16,7 +15,7 @@ rootfs:
     url: "https://testtar.com/test-tar.tar"
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_git_gadget_without_url.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_git_gadget_without_url.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   branch: classic
   type: "git"
@@ -23,7 +22,7 @@ rootfs:
       - ubuntu-server-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_copy.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_copy.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: "classic"
@@ -27,7 +26,7 @@ rootfs:
       - ubuntu-server-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_touch_file.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_touch_file.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: "classic"
@@ -27,7 +26,7 @@ rootfs:
       - ubuntu-server-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_missing_name.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_missing_name.yaml
@@ -3,8 +3,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
@@ -23,7 +22,7 @@ rootfs:
       - ubuntu-server-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_prebuilt_gadget.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_prebuilt_gadget.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "file://test.tar"
   type: "directory"
@@ -23,7 +22,7 @@ rootfs:
       - ubuntu-server-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_private_ppa_without_fingerprint.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_private_ppa_without_fingerprint.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic

--- a/internal/statemachine/testdata/image_definitions/test_rootfs_seed.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_rootfs_seed.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
@@ -24,7 +23,7 @@ rootfs:
       - ubuntu-server-raspi
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_rootfs_tasks.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_rootfs_tasks.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: jammy
 class: preinstalled
-kernel:
-  name: linux-raspi
+kernel: linux-raspi
 gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
@@ -17,7 +16,7 @@ rootfs:
     - ubuntu-server
 customization:
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu

--- a/internal/statemachine/testdata/image_definitions/test_valid.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_valid.yaml
@@ -4,8 +4,7 @@ revision: 2
 architecture: arm64
 series: kinetic
 class: preinstalled
-kernel:
-  name: linux-image-raspi
+kernel: linux-image-raspi
 gadget:
   url: "https://github.com/jawn-smith/pi-gadget.git"
   branch: "classic"
@@ -38,7 +37,7 @@ customization:
     -
       name: "jawn-smith/devel-proposed"
   cloud-init:
-    user-data:
+    user-data: |
       -
         name: ubuntu
         password: ubuntu


### PR DESCRIPTION
This PR does the following miscellaneous cleanup tasks:

- Change the `kernel` image definition key to a single string
- Change the `cloud-init:user-data` key to a string
- Install the kernel from image definition during the install_packages state. This previously existed in the destination branch and got removed by a merge gone awry.