### PR TITLE
Set PATH environment variable in make command

### DIFF
--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -339,11 +339,13 @@ func (stateMachine *StateMachine) buildGadgetTree() error {
 
 	// now run "make" to build the gadget tree
 	makeCmd := execCommand("make")
+	// add ARCH and SERIES environment variables for making the gadget tree
 	makeCmd.Env = append(makeCmd.Env, []string{
 		fmt.Sprintf("ARCH=%s", classicStateMachine.ImageDef.Architecture),
 		fmt.Sprintf("SERIES=%s", classicStateMachine.ImageDef.Series),
-		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 	}...)
+	// add the current ENV to the command
+	makeCmd.Env = append(makeCmd.Env, os.Environ()...)
 	makeCmd.Dir = sourceDir
 
 	makeOutput := helper.SetCommandOutput(makeCmd, classicStateMachine.commonFlags.Debug)

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -342,6 +342,7 @@ func (stateMachine *StateMachine) buildGadgetTree() error {
 	makeCmd.Env = append(makeCmd.Env, []string{
 		fmt.Sprintf("ARCH=%s", classicStateMachine.ImageDef.Architecture),
 		fmt.Sprintf("SERIES=%s", classicStateMachine.ImageDef.Series),
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 	}...)
 	makeCmd.Dir = sourceDir
 


### PR DESCRIPTION
When testing building of raspi images I noticed the make command failing to find `binaries` in /usr/bin. This is because now that we're setting the ARCH and SERIES environment vars PATH was being dropped.

I propose just setting PATH and ignoring the rest of the env vars in the shell that is invoking the command, but I'm open to changing if we think that is more appropriate.