### PR TITLE
Remove sudo from manifest generation as classic has to be run as root

### DIFF
--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -893,7 +893,7 @@ func (stateMachine *StateMachine) generatePackageManifest() error {
 	// This is basically just a wrapper around dpkg-query
 	outputPath := filepath.Join(stateMachine.commonFlags.OutputDir,
 		classicStateMachine.ImageDef.Artifacts.Manifest.ManifestName)
-	cmd := execCommand("sudo", "chroot", stateMachine.tempDirs.rootfs, "dpkg-query", "-W", "--showformat=${Package} ${Version}\n")
+	cmd := execCommand("chroot", stateMachine.tempDirs.rootfs, "dpkg-query", "-W", "--showformat=${Package} ${Version}\n")
 	manifest, err := os.Create(outputPath)
 	if err != nil {
 		return fmt.Errorf("Error creating manifest file: %s", err.Error())


### PR DESCRIPTION
This was causing some errors when running in a privileged container. Removing the `sudo` from the `chroot` command fixed it.

Since classic image builds have to be run with root privileges anyway, the `sudo` is not necessary.