### PR TITLE
Test output cleanup

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: install-go

--- a/.github/workflows/go-quality-checks.yml
+++ b/.github/workflows/go-quality-checks.yml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
       - name: go-vet

--- a/.github/workflows/inclusive-naming.yml
+++ b/.github/workflows/inclusive-naming.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: tj-actions/changed-files@v18.7
         id: files

--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -11,7 +11,7 @@ jobs:
           - ubuntu-18.04
           - ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Download spread

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -321,6 +321,11 @@ func TestPrepareGadgetTree(t *testing.T) {
 		var stateMachine ClassicStateMachine
 		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 		stateMachine.parent = &stateMachine
+		stateMachine.ImageDef = imagedefinition.ImageDefinition{
+			Architecture: getHostArch(),
+			Series:       getHostSuite(),
+			Gadget:       &imagedefinition.Gadget{},
+		}
 
 		// need workdir set up for this
 		err := stateMachine.makeTemporaryDirectories()
@@ -346,6 +351,43 @@ func TestPrepareGadgetTree(t *testing.T) {
 	})
 }
 
+// TestPrepareGadgetTreePrebuilt tests the prepareGadgetTree function with prebuilt gadgets
+func TestPrepareGadgetTreePrebuilt(t *testing.T) {
+	t.Run("test_prepare_gadget_tree_prebuilt", func(t *testing.T) {
+		asserter := helper.Asserter{T: t}
+		saveCWD := helper.SaveCWD()
+		defer saveCWD()
+
+		var stateMachine ClassicStateMachine
+		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+		stateMachine.parent = &stateMachine
+		stateMachine.ImageDef = imagedefinition.ImageDefinition{
+			Architecture: getHostArch(),
+			Series:       getHostSuite(),
+			Gadget: &imagedefinition.Gadget{
+				GadgetType: "prebuilt",
+				GadgetURL:  "testdata/gadget_tree/",
+			},
+		}
+
+		// need workdir set up for this
+		err := stateMachine.makeTemporaryDirectories()
+		asserter.AssertErrNil(err, true)
+
+		err = stateMachine.prepareGadgetTree()
+		asserter.AssertErrNil(err, true)
+
+		gadgetTreeFiles := []string{"grub.conf", "pc-boot.img", "meta/gadget.yaml"}
+		for _, file := range gadgetTreeFiles {
+			_, err := os.Stat(filepath.Join(stateMachine.tempDirs.unpack, "gadget", file))
+			if err != nil {
+				t.Errorf("File %s should be in unpack, but is missing", file)
+			}
+		}
+		os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
+	})
+}
+
 // TestFailedPrepareGadgetTree tests failures in os, osutil, and ioutil libraries
 func TestFailedPrepareGadgetTree(t *testing.T) {
 	t.Run("test_failed_prepare_gadget_tree", func(t *testing.T) {
@@ -353,6 +395,11 @@ func TestFailedPrepareGadgetTree(t *testing.T) {
 		var stateMachine ClassicStateMachine
 		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 		stateMachine.parent = &stateMachine
+		stateMachine.ImageDef = imagedefinition.ImageDefinition{
+			Architecture: getHostArch(),
+			Series:       getHostSuite(),
+			Gadget:       &imagedefinition.Gadget{},
+		}
 
 		// need workdir set up for this
 		err := stateMachine.makeTemporaryDirectories()

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -990,10 +990,14 @@ func TestFailedMakeDisk(t *testing.T) {
 		}()
 		stateMachine.cleanWorkDir = true // for coverage!
 		stateMachine.commonFlags.OutputDir = ""
+		defer os.Remove("pc.img")
 		err = stateMachine.makeDisk()
 		asserter.AssertErrContains(err, "Error writing disk image")
 		helperCopyBlob = helper.CopyBlob
-		os.Remove("pc.img")
+
+		// make sure with no OutputDir the image was created in the cwd
+		_, err = os.Stat("pc.img")
+		asserter.AssertErrNil(err, true)
 	})
 }
 

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -993,6 +993,7 @@ func TestFailedMakeDisk(t *testing.T) {
 		err = stateMachine.makeDisk()
 		asserter.AssertErrContains(err, "Error writing disk image")
 		helperCopyBlob = helper.CopyBlob
+		os.Remove("pc.img")
 	})
 }
 

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -327,16 +327,18 @@ func TestFailedCopyStructureContent(t *testing.T) {
 // state machine has finished running
 func TestCleanup(t *testing.T) {
 	t.Run("test_cleanup", func(t *testing.T) {
+		asserter := helper.Asserter{T: t}
 		var stateMachine StateMachine
 		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
-		stateMachine.Run()
+		// create the workdir and make sure it is set to be cleaned up
+		err := stateMachine.makeTemporaryDirectories()
+		asserter.AssertErrNil(err, true)
+		stateMachine.cleanWorkDir = true
 		stateMachine.Teardown()
 		if _, err := os.Stat(stateMachine.stateMachineFlags.WorkDir); err == nil {
 			t.Errorf("Error: temporary workdir %s was not cleaned up\n",
 				stateMachine.stateMachineFlags.WorkDir)
 		}
-		// remove a leftover artifact
-		os.Remove("ubuntu-image.gob")
 	})
 }
 

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -335,6 +335,8 @@ func TestCleanup(t *testing.T) {
 			t.Errorf("Error: temporary workdir %s was not cleaned up\n",
 				stateMachine.stateMachineFlags.WorkDir)
 		}
+		// remove a leftover artifact
+		os.Remove("ubuntu-image.gob")
 	})
 }
 

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -708,12 +708,17 @@ func TestFailedPostProcessGadgetYaml(t *testing.T) {
 		asserter := helper.Asserter{T: t}
 		var stateMachine StateMachine
 		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+
+		// need workdir set up for this
+		err := stateMachine.makeTemporaryDirectories()
+		asserter.AssertErrNil(err, false)
+
 		// set a valid yaml file and load it in
 		stateMachine.YamlFilePath = filepath.Join("testdata",
 			"gadget_tree", "meta", "gadget.yaml")
 		// ensure unpack exists
 		os.MkdirAll(stateMachine.tempDirs.unpack, 0755)
-		err := stateMachine.loadGadgetYaml()
+		err = stateMachine.loadGadgetYaml()
 		asserter.AssertErrNil(err, false)
 
 		// mock filepath.Rel


### PR DESCRIPTION
While improving my tooling I noticed that running the test suite was leaving some leftover files in the git file tree. This PR cleans up those files, while also updating to actions/checkout@v3, since v2 was recently deprecated.