### PR TITLE
Manifest error messaging improvements

### DIFF
--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -1432,23 +1432,9 @@ func TestGeneratePackageManifest(t *testing.T) {
 func TestFailedGeneratePackageManifest(t *testing.T) {
 	t.Run("test_failed_generate_package_manifest", func(t *testing.T) {
 		asserter := helper.Asserter{T: t}
-
-		// Setup the exec.Command mock - version from the success test
-		testCaseName = "TestGeneratePackageManifest"
-		execCommand = fakeExecCommand
-		defer func() {
-			execCommand = exec.Command
-		}()
-		// Setup the mock for os.Create, making those fail
-		osCreate = mockCreate
-		defer func() {
-			osCreate = os.Create
-		}()
-
 		var stateMachine ClassicStateMachine
 		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 		stateMachine.parent = &stateMachine
-		stateMachine.commonFlags.OutputDir = "/test/path"
 		stateMachine.ImageDef = imagedefinition.ImageDefinition{
 			Architecture: getHostArch(),
 			Series:       getHostSuite(),
@@ -1463,8 +1449,37 @@ func TestFailedGeneratePackageManifest(t *testing.T) {
 			},
 		}
 
-		err := stateMachine.generatePackageManifest()
+		// We need the output directory set for this
+		outputDir, err := ioutil.TempDir("/tmp", "ubuntu-image-")
+		asserter.AssertErrNil(err, true)
+		defer os.RemoveAll(outputDir)
+		stateMachine.commonFlags.OutputDir = outputDir
+
+		// Setup the exec.Command mock - version from the success test
+		testCaseName = "TestGeneratePackageManifest"
+		execCommand = fakeExecCommand
+		defer func() {
+			execCommand = exec.Command
+		}()
+
+		// Setup the mock for os.Create, making those fail
+		osCreate = mockCreate
+		defer func() {
+			osCreate = os.Create
+		}()
+
+		err = stateMachine.generatePackageManifest()
 		asserter.AssertErrContains(err, "Error creating manifest file")
+		osCreate = os.Create
+
+		// Setup the exec.Command mock - version from the fail test
+		testCaseName = "TestFailedGeneratePackageManifest"
+		execCommand = fakeExecCommand
+		defer func() {
+			execCommand = exec.Command
+		}()
+		err = stateMachine.generatePackageManifest()
+		asserter.AssertErrContains(err, "Error generating package manifest with command")
 	})
 }
 
@@ -1535,7 +1550,6 @@ func TestFailedGenerateFilelist(t *testing.T) {
 		var stateMachine ClassicStateMachine
 		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 		stateMachine.parent = &stateMachine
-		stateMachine.commonFlags.OutputDir = "/test/path"
 		stateMachine.ImageDef = imagedefinition.ImageDefinition{
 			Architecture: getHostArch(),
 			Series:       getHostSuite(),
@@ -1550,8 +1564,37 @@ func TestFailedGenerateFilelist(t *testing.T) {
 			},
 		}
 
-		err := stateMachine.generateFilelist()
-		asserter.AssertErrContains(err, "Error creating filelist file")
+		// We need the output directory set for this
+		outputDir, err := ioutil.TempDir("/tmp", "ubuntu-image-")
+		asserter.AssertErrNil(err, true)
+		defer os.RemoveAll(outputDir)
+		stateMachine.commonFlags.OutputDir = outputDir
+
+		// Setup the exec.Command mock - version from the success test
+		testCaseName = "TestGenerateFilelist"
+		execCommand = fakeExecCommand
+		defer func() {
+			execCommand = exec.Command
+		}()
+
+		// Setup the mock for os.Create, making those fail
+		osCreate = mockCreate
+		defer func() {
+			osCreate = os.Create
+		}()
+
+		err = stateMachine.generateFilelist()
+		asserter.AssertErrContains(err, "Error creating filelist")
+		osCreate = os.Create
+
+		// Setup the exec.Command mock - version from the fail test
+		testCaseName = "TestFailedGenerateFilelist"
+		execCommand = fakeExecCommand
+		defer func() {
+			execCommand = exec.Command
+		}()
+		err = stateMachine.generateFilelist()
+		asserter.AssertErrContains(err, "Error generating file list with command")
 	})
 }
 

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -201,6 +201,13 @@ func TestExecHelperProcess(t *testing.T) {
 	case "TestGeneratePackageManifest":
 		fmt.Fprint(os.Stdout, "foo 1.2\nbar 1.4-1ubuntu4.1\nlibbaz 0.1.3ubuntu2\n")
 		break
+	case "TestGenerateFilelist":
+		fmt.Fprint(os.Stdout, "/root\n/home\n/var")
+		break
+	case "TestFailedGeneratePackageManifest":
+		fallthrough
+	case "TestFailedGenerateFilelist":
+		fallthrough
 	case "TestFailedGerminate":
 		fallthrough
 	case "TestFailedSetupLiveBuildCommands":

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap1~beta6
+version: 3.0+snap1~beta7
 grade: stable
 confinement: classic
 base: core20


### PR DESCRIPTION
Someone who is testing this software is getting an error while trying to generate a package manifest. The error is not very helpful, so this error messaging should be improved to help debug their issue.