### PR TITLE
Pull in latest snapd to resolve issue with defaults in gadgets

### DIFF
--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -16,9 +16,9 @@ jobs:
           fetch-depth: 2
       - name: Download spread
         run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | tar -xz
-      - name: install-test-dependencies
-        run: sudo apt install -y gcc golang-go libc6-dev
       - name: Init lxd
         run: sudo lxd init --auto
+      - name: install-golang-snap
+        run: sudo snap refresh go --channel=1.19/stable
       - name: Run spread tests
         run: sudo ./spread lxd:${{ matrix.system }}

--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   spread:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         system:
@@ -18,7 +18,5 @@ jobs:
         run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | tar -xz
       - name: Init lxd
         run: sudo lxd init --auto
-      - name: install-golang-snap
-        run: sudo snap install go --channel=1.19/stable --classic
       - name: Run spread tests
         run: sudo ./spread lxd:${{ matrix.system }}

--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   spread:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         system:

--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Download spread
         run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | tar -xz
       - name: install-test-dependencies
-        run: sudo apt install -y gcc libc6-dev
+        run: sudo apt install -y gcc golang-go libc6-dev
       - name: Init lxd
         run: sudo lxd init --auto
       - name: Run spread tests

--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: install-test-dependencies
-        run: sudo apt install -y gcc libc6-dev
       - name: Download spread
         run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | tar -xz
+      - name: install-test-dependencies
+        run: sudo apt install -y gcc libc6-dev
       - name: Init lxd
         run: sudo lxd init --auto
       - name: Run spread tests

--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -19,6 +19,6 @@ jobs:
       - name: Init lxd
         run: sudo lxd init --auto
       - name: install-golang-snap
-        run: sudo snap refresh go --channel=1.19/stable
+        run: sudo snap install go --channel=1.19/stable --classic
       - name: Run spread tests
         run: sudo ./spread lxd:${{ matrix.system }}

--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
+      - name: install-test-dependencies
+        run: sudo apt install -y gcc libc6-dev
       - name: Download spread
         run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | tar -xz
       - name: Init lxd

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/diskfs/go-diskfs v0.0.0-20211104185512-274de576a1a5
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/jessevdk/go-flags v1.5.0
+	github.com/jessevdk/go-flags v1.5.1-0.20210607101731-3927b71304df
 	github.com/mvo5/goconfigparser v0.0.0-20201015074339-50f22f44deb5 // indirect
 	github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2 // indirect
-	github.com/snapcore/snapd v0.0.0-20220927112420-6e453dafb812
+	github.com/snapcore/snapd v0.0.0-20221129075508-c3311229fa85
 	gopkg.in/macaroon.v1 v1.0.0 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/go-efilib v0.0.0-20210909101908-41435fa545d4 h1:rSWREoNHHbcIC1iQeKKraBlsDm7cmKg8eS+N48jMVKA=
-github.com/canonical/go-efilib v0.0.0-20210909101908-41435fa545d4/go.mod h1:9Sr9kd7IhQPYqaU5nut8Ky97/CtlhHDzQncQnrULgDM=
+github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93 h1:F0bRDzPy/j2IX/iIWqCEA23S1nal+f7A+/vLyj6Ye+4=
+github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93/go.mod h1:9b2PNAuPcZsB76x75/uwH99D8CyH/A2y4rq1/+bvplg=
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 h1:USzKjrfWo/ESzozv2i3OMM7XDgxrZRvaHFrKkIKRtwU=
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9/go.mod h1:Zrs3YjJr+w51u0R/dyLh/oWt/EcBVdLPCVFYC4daW5s=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6fCvaEpkhyW3qAicT0TnGtyht/UrgvOwMcEgLb7Aw=
@@ -30,9 +30,9 @@ github.com/gorilla/mux v1.7.4-0.20190701202633-d83b6ffe499a/go.mod h1:1lud6UwP+6
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gvalkov/golang-evdev v0.0.0-20191114124502-287e62b94bcb/go.mod h1:SAzVFKCRezozJTGavF3GX8MBUruETCqzivVLYiywouA=
-github.com/jessevdk/go-flags v1.4.1-0.20180927143258-7309ec74f752/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jessevdk/go-flags v1.5.1-0.20210607101731-3927b71304df h1:JTDw/M13b6dZmEJI/vfcCLENqcjUHi9UBry+R0pjh5Q=
+github.com/jessevdk/go-flags v1.5.1-0.20210607101731-3927b71304df/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/juju/ratelimit v1.0.1 h1:+7AIFJVQ0EQgq/K9+0Krm7m530Du7tIz0METWzN0RgY=
 github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -63,11 +63,11 @@ github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8/go.mod h1:Z6z3sf12
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
 github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2 h1:nETXPg0CiJrMAwC2gqkcam9BiBWYGvTsSYRfrjOz2Kg=
 github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
-github.com/snapcore/secboot v0.0.0-20220905094328-6a625ee231d3 h1:58BNTUsb16y89bcfYRU23V9ykMhOHHGy9zrVKgKFiqU=
-github.com/snapcore/secboot v0.0.0-20220905094328-6a625ee231d3/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
+github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2 h1:sPC5tmNoJ6H8Pu9OHZiYP1YIAlG98Nm44CYS9nliPz0=
+github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
-github.com/snapcore/snapd v0.0.0-20220927112420-6e453dafb812 h1:dVhWt4aHNjxUyHFjAs/56O+883CMV6G7Oz7U/JuQLZw=
-github.com/snapcore/snapd v0.0.0-20220927112420-6e453dafb812/go.mod h1:IIRpg6/P+gndMxKk1ZxPUJ2Z9Q80+PVFhvyq3rCgHeY=
+github.com/snapcore/snapd v0.0.0-20221129075508-c3311229fa85 h1:1KxhNn5BKhQug8Ph+FZhUFJUp8VGjZ5P1j9YGgALeXA=
+github.com/snapcore/snapd v0.0.0-20221129075508-c3311229fa85/go.mod h1:smkkw6QWeTo9l8t9gxqLcbFzBOPZpeJxa2bHZWWcTYY=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 2.2+snap10
+version: 2.2+snap11
 grade: stable
 confinement: classic
 base: core20

--- a/spread.yaml
+++ b/spread.yaml
@@ -11,9 +11,10 @@ path: /home/ubuntu-image
 
 prepare: |
   apt update
-  apt install -y snapd
+  apt install -y snapd libc6-dev gcc
   snap install core20 --channel=latest/edge
   snap install --classic snapcraft
+  snap install --classic go --channel=1.19/stable
   unset SHELL
   snapcraft --destructive-mode
   snap install --classic --dangerous ubuntu-image_*.snap


### PR DESCRIPTION
There was a bug in snapd with using `defaults` in the gadget while also trying to apply customizations (like cloud-init configs). This was fixed in snapd and tests for it exist there, so this PR just pulls in the latest snapd.