### PR TITLE
i/statemachine: remove generation of seed.manifest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.1-0.20210607101731-3927b71304df
 	github.com/mvo5/goconfigparser v0.0.0-20201015074339-50f22f44deb5 // indirect
 	github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2 // indirect
-	github.com/snapcore/snapd v0.0.0-20221213091249-ec6b35d578f4
+	github.com/snapcore/snapd v0.0.0-20230110165810-bb2514455dea
 	gopkg.in/macaroon.v1 v1.0.0 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2/go.mod h1:D3Ss
 github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2 h1:sPC5tmNoJ6H8Pu9OHZiYP1YIAlG98Nm44CYS9nliPz0=
 github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
-github.com/snapcore/snapd v0.0.0-20221213091249-ec6b35d578f4 h1:7gIILq9+nX1i+lVrhUzrJP357muA9ATGFMKYJGME2rQ=
-github.com/snapcore/snapd v0.0.0-20221213091249-ec6b35d578f4/go.mod h1:smkkw6QWeTo9l8t9gxqLcbFzBOPZpeJxa2bHZWWcTYY=
+github.com/snapcore/snapd v0.0.0-20230110165810-bb2514455dea h1:sKRBg9nQLoYJ11ySb7EHOdYJFTBoKXHDr8aLZcFet2Q=
+github.com/snapcore/snapd v0.0.0-20230110165810-bb2514455dea/go.mod h1:smkkw6QWeTo9l8t9gxqLcbFzBOPZpeJxa2bHZWWcTYY=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=

--- a/internal/statemachine/snap_states.go
+++ b/internal/statemachine/snap_states.go
@@ -33,6 +33,7 @@ func (stateMachine *StateMachine) prepareImage() error {
 	imageOpts.Preseed = snapStateMachine.Opts.Preseed
 	imageOpts.PreseedSignKey = snapStateMachine.Opts.PreseedSignKey
 	imageOpts.AppArmorKernelFeaturesDir = snapStateMachine.Opts.AppArmorKernelFeaturesDir
+	imageOpts.SeedManifestPath = filepath.Join(stateMachine.commonFlags.OutputDir, "seed.manifest")
 
 	customizations := *new(image.Customizations)
 	if snapStateMachine.Opts.DisableConsoleConf {
@@ -106,19 +107,5 @@ func (stateMachine *StateMachine) generateSnapManifest() error {
 	// snaps.manifest
 	outputPath := filepath.Join(stateMachine.commonFlags.OutputDir, "snaps.manifest")
 	snapsDir := filepath.Join(stateMachine.tempDirs.rootfs, "system-data", "var", "lib", "snapd", "snaps")
-	err := WriteSnapManifest(snapsDir, outputPath)
-	if err != nil {
-		return err
-	}
-
-	// seed.manifest
-	outputPath = filepath.Join(stateMachine.commonFlags.OutputDir, "seed.manifest")
-	if stateMachine.IsSeeded {
-		snapsDir = filepath.Join(stateMachine.tempDirs.rootfs, "snaps")
-	} else {
-		snapsDir = filepath.Join(stateMachine.tempDirs.rootfs, "system-data", "var", "lib", "snapd", "seed", "snaps")
-	}
-	err = WriteSnapManifest(snapsDir, outputPath)
-
-	return err
+	return WriteSnapManifest(snapsDir, outputPath)
 }

--- a/internal/statemachine/snap_test.go
+++ b/internal/statemachine/snap_test.go
@@ -293,14 +293,9 @@ func TestGenerateSnapManifest(t *testing.T) {
 			// Check if manifests got generated and if they have expected contents
 			// For both UC20+ and regular images
 			var testResultMap map[string][]string
-			if tc.seeded {
-				testResultMap = map[string][]string{
-					"seed.manifest": {"foo 1.23", "uc20specific 345"},
-				}
-			} else {
+			if !tc.seeded {
 				testResultMap = map[string][]string{
 					"snaps.manifest": {"foo 1.23", "bar 1.23_version", "baz 234"},
-					"seed.manifest":  {"foo 1.23", "test 1234"},
 				}
 			}
 			for manifest, snapList := range testResultMap {

--- a/internal/statemachine/snap_test.go
+++ b/internal/statemachine/snap_test.go
@@ -426,6 +426,7 @@ func TestSnapFlagSyntax(t *testing.T) {
 			asserter.AssertErrNil(err, true)
 			defer os.RemoveAll(workDir)
 			stateMachine.stateMachineFlags.WorkDir = workDir
+			stateMachine.commonFlags.OutputDir = workDir
 
 			err = stateMachine.Setup()
 			asserter.AssertErrNil(err, true)


### PR DESCRIPTION
We need the ability to generate and parse seed.manifest's in `snap prepare-image` as a part of our goal to have reproducible image builds. So instead of having ubuntu-image do this, we move this ability into snap prepare-image.

From a user-perspective nothing should change.