### PR TITLE
allow non-sequential partition tables by adding in hidden partitions

### DIFF
--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -370,7 +370,7 @@ func createPartitionTable(volumeName string, volume *gadget.Volume, sectorSize u
 				Type:     mbr.Type(partitionType),
 				Bootable: bootable,
 			}
-			for (i+1) < structure.PartitionNumber {
+			for (i + 1) < structure.PartitionNumber {
 				mbrPartitions = append(mbrPartitions, &mbr.Partition{
 					Start: uint32(offset),
 					Size:  1,
@@ -397,7 +397,7 @@ func createPartitionTable(volumeName string, volume *gadget.Volume, sectorSize u
 			}
 			offset = offset + gptPartition.Size
 			gptPartitions = append(gptPartitions, gptPartition)
-			for (i+1) < structure.PartitionNumber {
+			for (i + 1) < structure.PartitionNumber {
 				gptPartitions = append(gptPartitions, &gpt.Partition{
 					Start: offset,
 					Size:  1,

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -370,12 +370,13 @@ func createPartitionTable(volumeName string, volume *gadget.Volume, sectorSize u
 				Type:     mbr.Type(partitionType),
 				Bootable: bootable,
 			}
-			for i < structure.PartitionNumber {
+			for (i+1) < structure.PartitionNumber {
 				mbrPartitions = append(mbrPartitions, &mbr.Partition{
 					Start: uint32(offset),
 					Size:  1,
 					Type:  0x00,
 				})
+				i++
 			}
 			mbrPartitions = append(mbrPartitions, mbrPartition)
 			offset = offset + uint64(mbrPartition.Size)
@@ -394,15 +395,15 @@ func createPartitionTable(volumeName string, volume *gadget.Volume, sectorSize u
 				Type:  partitionType,
 				Name:  partitionName,
 			}
-			fmt.Println(gptPartition)
 			offset = offset + gptPartition.Size
 			gptPartitions = append(gptPartitions, gptPartition)
-			for i < structure.PartitionNumber {
+			for (i+1) < structure.PartitionNumber {
 				gptPartitions = append(gptPartitions, &gpt.Partition{
 					Start: offset,
 					Size:  1,
 					Type:  "00000000-0000-0000-0000-000000000000",
 				})
+				i++
 			}
 			offset = offset + gptPartition.Size
 		}


### PR DESCRIPTION
This is just a proof of concept that only worked with a locally forked snapd/pc-amd64-gadget.