### PR TITLE
Fix extra ppa/snap/packages logic for prebuilt rootfs

### DIFF
--- a/internal/imagedefinition/image_definition.go
+++ b/internal/imagedefinition/image_definition.go
@@ -66,14 +66,14 @@ type Tarball struct {
 }
 
 // Customization defines the customization section of the image definition file.
-// The extra_step struct tag denotes that an extra state will need to be added
-// for image builds with prebuilt root filesystems.
+// The extra_step_prebuilt_rootfs struct tag denotes that an extra state will
+// need to be added for image builds with prebuilt root filesystems.
 type Customization struct {
 	Installer     *Installer `yaml:"installer"      json:"Installer,omitempty"`
 	CloudInit     *CloudInit `yaml:"cloud-init"     json:"CloudInit,omitempty"`
-	ExtraPPAs     []*PPA     `yaml:"extra-ppas"     json:"ExtraPPAs,omitempty"     extra_step:"add_extra_ppas"`
-	ExtraPackages []*Package `yaml:"extra-packages" json:"ExtraPackages,omitempty" extra_step:"install_extra_packages"`
-	ExtraSnaps    []*Snap    `yaml:"extra-snaps"    json:"ExtraSnaps,omitempty"    extra_step:"install_extra_snaps"`
+	ExtraPPAs     []*PPA     `yaml:"extra-ppas"     json:"ExtraPPAs,omitempty"     extra_step_prebuilt_rootfs:"add_extra_ppas"`
+	ExtraPackages []*Package `yaml:"extra-packages" json:"ExtraPackages,omitempty" extra_step_prebuilt_rootfs:"install_extra_packages"`
+	ExtraSnaps    []*Snap    `yaml:"extra-snaps"    json:"ExtraSnaps,omitempty"    extra_step_prebuilt_rootfs:"install_extra_snaps"`
 	Fstab         []*Fstab   `yaml:"fstab"          json:"Fstab,omitempty"`
 	Manual        *Manual    `yaml:"manual"         json:"Manual,omitempty"`
 }

--- a/internal/imagedefinition/image_definition.go
+++ b/internal/imagedefinition/image_definition.go
@@ -65,13 +65,15 @@ type Tarball struct {
 	SHA256sum  string `yaml:"sha256sum" json:"SHA256sum,omitempty" jsonschema:"minLength=64,maxLength=64"`
 }
 
-// Customization defines the customization section of the image definition file
+// Customization defines the customization section of the image definition file.
+// The extra_step struct tag denotes that an extra state will need to be added
+// for image builds with prebuilt root filesystems.
 type Customization struct {
 	Installer     *Installer `yaml:"installer"      json:"Installer,omitempty"`
 	CloudInit     *CloudInit `yaml:"cloud-init"     json:"CloudInit,omitempty"`
-	ExtraPPAs     []*PPA     `yaml:"extra-ppas"     json:"ExtraPPAs,omitempty"`
-	ExtraPackages []*Package `yaml:"extra-packages" json:"ExtraPackages,omitempty"`
-	ExtraSnaps    []*Snap    `yaml:"extra-snaps"    json:"ExtraSnaps,omitempty"`
+	ExtraPPAs     []*PPA     `yaml:"extra-ppas"     json:"ExtraPPAs,omitempty"     extra_step:"add_extra_ppas"`
+	ExtraPackages []*Package `yaml:"extra-packages" json:"ExtraPackages,omitempty" extra_step:"install_extra_packages"`
+	ExtraSnaps    []*Snap    `yaml:"extra-snaps"    json:"ExtraSnaps,omitempty"    extra_step:"install_extra_snaps"`
 	Fstab         []*Fstab   `yaml:"fstab"          json:"Fstab,omitempty"`
 	Manual        *Manual    `yaml:"manual"         json:"Manual,omitempty"`
 }

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -245,6 +245,20 @@ func (stateMachine *StateMachine) calculateStates() error {
 	if classicStateMachine.ImageDef.Rootfs.Tarball != nil {
 		rootfsCreationStates = append(rootfsCreationStates,
 			stateFunc{"extract_rootfs_tar", (*StateMachine).extractRootfsTar})
+		// if there are extra snaps or packages to install, these will have
+		// to be done as separate steps
+		if len(classicStateMachine.ImageDef.Customization.ExtraPPAs) > 0 {
+			rootfsCreationStates = append(rootfsCreationStates,
+				stateFunc{"add_extra_ppas", (*StateMachine).addExtraPPAs})
+		}
+		if len(classicStateMachine.ImageDef.Customization.ExtraPackages) > 0 {
+			rootfsCreationStates = append(rootfsCreationStates,
+				stateFunc{"install_extra_packages", (*StateMachine).installPackages})
+		}
+		if len(classicStateMachine.ImageDef.Customization.ExtraSnaps) > 0 {
+			rootfsCreationStates = append(rootfsCreationStates,
+				stateFunc{"install_extra_snaps", (*StateMachine).preseedClassicImage})
+		}
 	} else if classicStateMachine.ImageDef.Rootfs.Seed != nil {
 		rootfsCreationStates = append(rootfsCreationStates, rootfsSeedStates...)
 		if classicStateMachine.ImageDef.Customization != nil {
@@ -838,20 +852,6 @@ func (stateMachine *StateMachine) customizeCloudInit() error {
 	_, err = dpkgConfigFile.WriteString(datasourceConfig)
 
 	return err
-}
-
-// Configure Extra PPAs
-func (stateMachine *StateMachine) setupExtraPPAs() error {
-	// currently a no-op pending implementation of the classic image redesign
-	return nil
-}
-
-// Install extra packages
-// TODO: this should probably happen during the rootfs build steps.
-// but what about extra packages with a tarball based images...
-func (stateMachine *StateMachine) installExtraPackages() error {
-	// currently a no-op pending implementation of the classic image redesign
-	return nil
 }
 
 // Customize /etc/fstab based on values in the image definition

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -246,10 +246,12 @@ func (stateMachine *StateMachine) calculateStates() error {
 		rootfsCreationStates = append(rootfsCreationStates,
 			stateFunc{"extract_rootfs_tar", (*StateMachine).extractRootfsTar})
 		// if there are extra snaps or packages to install, these will have
-		// to be done as separate steps
+		// to be done as separate steps. To add one of these extra steps, add the
+		// struct tag "extra_step_prebuilt_rootfs" to a field in the image definition
+		// that should trigger an extra step
 		if classicStateMachine.ImageDef.Customization != nil {
 			extraStates := checkCustomizationSteps(classicStateMachine.ImageDef.Customization,
-				"extra_step",
+				"extra_step_prebuilt_rootfs",
 			)
 			rootfsCreationStates = append(rootfsCreationStates, extraStates...)
 		}

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -248,10 +248,9 @@ func (stateMachine *StateMachine) calculateStates() error {
 		// if there are extra snaps or packages to install, these will have
 		// to be done as separate steps
 		if classicStateMachine.ImageDef.Customization != nil {
-			extraStates, err := CheckCustomizationSteps(classicStateMachine.ImageDef.Customization, "extra_step")
-			if err != nil {
-				return fmt.Errorf("Error determining extra customization steps: \"%s\"", err.Error())
-			}
+			extraStates := checkCustomizationSteps(classicStateMachine.ImageDef.Customization,
+				"extra_step",
+			)
 			rootfsCreationStates = append(rootfsCreationStates, extraStates...)
 		}
 	} else if classicStateMachine.ImageDef.Rootfs.Seed != nil {

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -247,17 +247,12 @@ func (stateMachine *StateMachine) calculateStates() error {
 			stateFunc{"extract_rootfs_tar", (*StateMachine).extractRootfsTar})
 		// if there are extra snaps or packages to install, these will have
 		// to be done as separate steps
-		if len(classicStateMachine.ImageDef.Customization.ExtraPPAs) > 0 {
-			rootfsCreationStates = append(rootfsCreationStates,
-				stateFunc{"add_extra_ppas", (*StateMachine).addExtraPPAs})
-		}
-		if len(classicStateMachine.ImageDef.Customization.ExtraPackages) > 0 {
-			rootfsCreationStates = append(rootfsCreationStates,
-				stateFunc{"install_extra_packages", (*StateMachine).installPackages})
-		}
-		if len(classicStateMachine.ImageDef.Customization.ExtraSnaps) > 0 {
-			rootfsCreationStates = append(rootfsCreationStates,
-				stateFunc{"install_extra_snaps", (*StateMachine).preseedClassicImage})
+		if classicStateMachine.ImageDef.Customization != nil {
+			extraStates, err := CheckCustomizationSteps(classicStateMachine.ImageDef.Customization, "extra_step")
+			if err != nil {
+				return fmt.Errorf("Error determining extra customization steps: \"%s\"", err.Error())
+			}
+			rootfsCreationStates = append(rootfsCreationStates, extraStates...)
 		}
 	} else if classicStateMachine.ImageDef.Rootfs.Seed != nil {
 		rootfsCreationStates = append(rootfsCreationStates, rootfsSeedStates...)

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -161,6 +161,7 @@ func TestCalculateStates(t *testing.T) {
 	}{
 		{"state_build_gadget", "test_build_gadget.yaml", []string{"build_gadget_tree", "load_gadget_yaml"}},
 		{"state_prebuilt_gadget", "test_prebuilt_gadget.yaml", []string{"prepare_gadget_tree", "load_gadget_yaml"}},
+		{"state_prebuilt_rootfs_extras", "test_prebuilt_rootfs_extras.yaml", []string{"add_extra_ppas", "install_extra_packages", "install_extra_snaps"}},
 		{"extract_rootfs_tar", "test_extract_rootfs_tar.yaml", []string{"extract_rootfs_tar"}},
 		{"build_rootfs_from_seed", "test_rootfs_seed.yaml", []string{"germinate"}},
 		{"build_rootfs_from_tasks", "test_rootfs_tasks.yaml", []string{"build_rootfs_from_tasks"}},
@@ -1208,40 +1209,6 @@ func TestFailedCustomizeCloudInit(t *testing.T) {
 		if err == nil {
 			t.Error()
 		}
-	})
-}
-
-// TestSetupExtraPPAs unit tests the setupExtraPPAs function
-func TestSetupExtraPPAs(t *testing.T) {
-	t.Run("test_setup_extra_PPAs", func(t *testing.T) {
-		asserter := helper.Asserter{T: t}
-		saveCWD := helper.SaveCWD()
-		defer saveCWD()
-
-		var stateMachine ClassicStateMachine
-		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
-
-		err := stateMachine.setupExtraPPAs()
-		asserter.AssertErrNil(err, true)
-
-		os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
-	})
-}
-
-// TestInstallExtraPackages unit tests the installExtraPackages function
-func TestInstallExtraPackages(t *testing.T) {
-	t.Run("test_install_extra_packages", func(t *testing.T) {
-		asserter := helper.Asserter{T: t}
-		saveCWD := helper.SaveCWD()
-		defer saveCWD()
-
-		var stateMachine ClassicStateMachine
-		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
-
-		err := stateMachine.installExtraPackages()
-		asserter.AssertErrNil(err, true)
-
-		os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
 	})
 }
 

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -855,20 +855,17 @@ func manualAddUser(addUserInterfaces interface{}, targetDir string, debug bool) 
 	return nil
 }
 
-// CheckCustomizationSteps examines a struct and returns a slice
+// checkCustomizationSteps examines a struct and returns a slice
 // of state functions that need to be manually added. It expects
 // the image definition's customization struct to be passed in and
 // uses struct tags to identify which state must be added
-func CheckCustomizationSteps(searchStruct interface{}, tag string) (extraStates []stateFunc, err error) {
+func checkCustomizationSteps(searchStruct interface{}, tag string) (extraStates []stateFunc) {
 	possibleStateFunc := map[string]stateFunc{
 		"add_extra_ppas":         stateFunc{"add_extra_ppas", (*StateMachine).addExtraPPAs},
 		"install_extra_packages": stateFunc{"install_extra_packages", (*StateMachine).installPackages},
 		"install_extra_snaps":    stateFunc{"install_extra_snaps", (*StateMachine).preseedClassicImage},
 	}
 	value := reflect.ValueOf(searchStruct)
-	if value.Kind() != reflect.Ptr {
-		return []stateFunc{}, fmt.Errorf("The argument to CheckCustomizationSteps must be a pointer")
-	}
 	elem := value.Elem()
 	for i := 0; i < elem.NumField(); i++ {
 		field := elem.Field(i)
@@ -880,5 +877,5 @@ func CheckCustomizationSteps(searchStruct interface{}, tag string) (extraStates 
 			}
 		}
 	}
-	return extraStates, nil
+	return extraStates
 }

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -812,7 +812,7 @@ func manualAddGroup(addGroupInterfaces interface{}, targetDir string, debug bool
 	addGroupSlice := reflect.ValueOf(addGroupInterfaces)
 	for i := 0; i < addGroupSlice.Len(); i++ {
 		addGroup := addGroupSlice.Index(i).Interface().(*imagedefinition.AddGroup)
-		addGroupCmd := execCommand("chroot", targetDir, "addgroup", addGroup.GroupName)
+		addGroupCmd := execCommand("chroot", targetDir, "groupadd", addGroup.GroupName)
 		debugStatement := fmt.Sprintf("Adding group \"%s\"\n", addGroup.GroupName)
 		if addGroup.GroupID != "" {
 			addGroupCmd.Args = append(addGroupCmd.Args, []string{"--gid", addGroup.GroupID}...)
@@ -836,7 +836,7 @@ func manualAddUser(addUserInterfaces interface{}, targetDir string, debug bool) 
 	addUserSlice := reflect.ValueOf(addUserInterfaces)
 	for i := 0; i < addUserSlice.Len(); i++ {
 		addUser := addUserSlice.Index(i).Interface().(*imagedefinition.AddUser)
-		addUserCmd := execCommand("chroot", targetDir, "adduser", addUser.UserName)
+		addUserCmd := execCommand("chroot", targetDir, "useradd", addUser.UserName)
 		debugStatement := fmt.Sprintf("Adding user \"%s\"\n", addUser.UserName)
 		if addUser.UserID != "" {
 			addUserCmd.Args = append(addUserCmd.Args, []string{"--uid", addUser.UserID}...)

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1168,3 +1168,100 @@ func TestLP1981720(t *testing.T) {
 		os.RemoveAll(contentRoot)
 	})
 }
+
+// TestCheckCustomizationSteps unit tests the checkCustomizationSteps function
+func TestCheckCustomizationSteps(t *testing.T) {
+	testCases := []struct {
+		name           string
+		customization  *imagedefinition.Customization
+		expectedSteps []string
+	}{
+		{
+			"add_extra_ppas",
+			&imagedefinition.Customization{
+				ExtraPPAs: []*imagedefinition.PPA{
+					{
+						PPAName: "test",
+					},
+				},
+			},
+			[]string{
+					"add_extra_ppas",
+			},
+		},
+		{
+			"install_extra_packages",
+			&imagedefinition.Customization{
+				ExtraPackages: []*imagedefinition.Package{
+					{
+						PackageName: "test",
+					},
+				},
+			},
+			[]string{
+					"install_extra_packages",
+			},
+		},
+		{
+			"install_extra_snaps",
+			&imagedefinition.Customization{
+				ExtraSnaps: []*imagedefinition.Snap{
+					{
+						SnapName: "test",
+					},
+				},
+			},
+			[]string{
+					"install_extra_snaps",
+			},
+		},
+		{
+			"all_extra_states",
+			&imagedefinition.Customization{
+				ExtraPPAs: []*imagedefinition.PPA{
+					{
+						PPAName: "test",
+					},
+				},
+				ExtraPackages: []*imagedefinition.Package{
+					{
+						PackageName: "test",
+					},
+				},
+				ExtraSnaps: []*imagedefinition.Snap{
+					{
+						SnapName: "test",
+					},
+				},
+			},
+			[]string{
+					"add_extra_ppas",
+					"install_extra_packages",
+					"install_extra_snaps",
+			},
+		},
+		{
+			"no_extra_states",
+			&imagedefinition.Customization{},
+			[]string{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("test_check_customization_steps_"+tc.name, func(t *testing.T) {
+			extraSteps := checkCustomizationSteps(tc.customization, "extra_step")
+			for _, stepName := range tc.expectedSteps {
+				found := false
+				for _, extraStep := range extraSteps {
+					if stepName == extraStep.name {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("Expected state \"%s\" to be added to the state machine but it was not",
+						stepName,
+					)
+				}
+			}
+		})
+	}
+}

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1172,8 +1172,8 @@ func TestLP1981720(t *testing.T) {
 // TestCheckCustomizationSteps unit tests the checkCustomizationSteps function
 func TestCheckCustomizationSteps(t *testing.T) {
 	testCases := []struct {
-		name           string
-		customization  *imagedefinition.Customization
+		name          string
+		customization *imagedefinition.Customization
 		expectedSteps []string
 	}{
 		{
@@ -1186,7 +1186,7 @@ func TestCheckCustomizationSteps(t *testing.T) {
 				},
 			},
 			[]string{
-					"add_extra_ppas",
+				"add_extra_ppas",
 			},
 		},
 		{
@@ -1199,7 +1199,7 @@ func TestCheckCustomizationSteps(t *testing.T) {
 				},
 			},
 			[]string{
-					"install_extra_packages",
+				"install_extra_packages",
 			},
 		},
 		{
@@ -1212,7 +1212,7 @@ func TestCheckCustomizationSteps(t *testing.T) {
 				},
 			},
 			[]string{
-					"install_extra_snaps",
+				"install_extra_snaps",
 			},
 		},
 		{
@@ -1235,9 +1235,9 @@ func TestCheckCustomizationSteps(t *testing.T) {
 				},
 			},
 			[]string{
-					"add_extra_ppas",
-					"install_extra_packages",
-					"install_extra_snaps",
+				"add_extra_ppas",
+				"install_extra_packages",
+				"install_extra_snaps",
 			},
 		},
 		{

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1248,7 +1248,7 @@ func TestCheckCustomizationSteps(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run("test_check_customization_steps_"+tc.name, func(t *testing.T) {
-			extraSteps := checkCustomizationSteps(tc.customization, "extra_step")
+			extraSteps := checkCustomizationSteps(tc.customization, "extra_step_prebuilt_rootfs")
 			for _, stepName := range tc.expectedSteps {
 				found := false
 				for _, extraStep := range extraSteps {

--- a/internal/statemachine/testdata/image_definitions/test_prebuilt_rootfs_extras.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_prebuilt_rootfs_extras.yaml
@@ -1,0 +1,37 @@
+name: ubuntu-server-raspi-arm64
+display-name: Ubuntu Server Raspberry Pi arm64
+revision: 2
+architecture: arm64
+series: jammy
+class: preinstalled
+kernel: linux-raspi
+gadget:
+  url: "file://test.tar"
+  type: "directory"
+model-assertion: pi-generic.model
+rootfs:
+  tarball:
+    url: "file://test.tar"
+customization:
+  cloud-init:
+    user-data: |
+      chpasswd:
+        expire: true
+        users:
+          - name: ubuntu
+            password: ubuntu
+            type: text
+  extra-packages:
+    - name: ubuntu-minimal
+    - name: linux-firmware-raspi
+    - name: pi-bluetooth
+  extra-snaps:
+    - name: hello
+  extra-ppas:
+    - name: test/ppa
+artifacts:
+  img:
+    -
+      name: raspi.img
+  manifest:
+    name: raspi.manifest

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap1~beta8
+version: 3.0+snap1~beta9
 grade: stable
 confinement: classic
 base: core20


### PR DESCRIPTION
There was previously a bug with some customization options not being applied for image builds using a prebuilt rootfs. This PR adds in those missing steps.