### PR TITLE
Fix logic for relative file paths

### DIFF
--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -433,8 +433,10 @@ func (stateMachine *StateMachine) prepareGadgetTree() error {
 	// recursively copy the gadget tree to unpack/gadget
 	var gadgetTree string
 	if classicStateMachine.ImageDef.Gadget.GadgetType == "prebuilt" {
-		gadgetURL, _ := url.Parse(classicStateMachine.ImageDef.Gadget.GadgetURL)
-		gadgetTree = gadgetURL.Path
+		gadgetTree = strings.TrimPrefix(classicStateMachine.ImageDef.Gadget.GadgetURL, "file://")
+		if !filepath.IsAbs(gadgetTree) {
+			gadgetTree, _ = filepath.Abs(gadgetTree)
+		}
 	} else {
 		gadgetTree = filepath.Join(classicStateMachine.tempDirs.scratch, "gadget")
 	}
@@ -705,11 +707,14 @@ func (stateMachine *StateMachine) extractRootfsTar() error {
 	// convert the URL to a file path
 	// no need to check error here as the validity of the URL
 	// has been confirmed by the schema validation
-	tarURL, _ := url.Parse(classicStateMachine.ImageDef.Rootfs.Tarball.TarballURL)
+	tarURL := strings.TrimPrefix(classicStateMachine.ImageDef.Rootfs.Tarball.TarballURL, "file://")
+	if !filepath.IsAbs(tarURL) {
+		tarURL, _ = filepath.Abs(tarURL)
+	}
 
 	// if the sha256 sum of the tarball is provided, make sure it matches
 	if classicStateMachine.ImageDef.Rootfs.Tarball.SHA256sum != "" {
-		tarSHA256, err := helper.CalculateSHA256(tarURL.Path)
+		tarSHA256, err := helper.CalculateSHA256(tarURL)
 		if err != nil {
 			return err
 		}
@@ -721,7 +726,7 @@ func (stateMachine *StateMachine) extractRootfsTar() error {
 	}
 
 	// now extract the archive
-	return helper.ExtractTarArchive(tarURL.Path, stateMachine.tempDirs.chroot,
+	return helper.ExtractTarArchive(tarURL, stateMachine.tempDirs.chroot,
 		stateMachine.commonFlags.Verbose, stateMachine.commonFlags.Debug)
 }
 

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -847,6 +847,7 @@ func TestBuildRootfsFromTasks(t *testing.T) {
 
 // TestExtractRootfsTar unit tests the extractRootfsTar function
 func TestExtractRootfsTar(t *testing.T) {
+	wd, _ := os.Getwd()
 	testCases := []struct {
 		name          string
 		rootfsTar     string
@@ -855,6 +856,15 @@ func TestExtractRootfsTar(t *testing.T) {
 	}{
 		{
 			"vanilla_tar",
+			filepath.Join(wd, "testdata", "rootfs_tarballs", "rootfs.tar"),
+			"ec01fd8488b0f35d2ca69e6f82edfaecef5725da70913bab61240419ce574918",
+			[]string{
+				"test_tar1",
+				"test_tar2",
+			},
+		},
+		{
+			"vanilla_tar_relative_path",
 			filepath.Join("testdata", "rootfs_tarballs", "rootfs.tar"),
 			"ec01fd8488b0f35d2ca69e6f82edfaecef5725da70913bab61240419ce574918",
 			[]string{
@@ -864,7 +874,7 @@ func TestExtractRootfsTar(t *testing.T) {
 		},
 		{
 			"gz",
-			filepath.Join("testdata", "rootfs_tarballs", "rootfs.tar.gz"),
+			filepath.Join(wd, "testdata", "rootfs_tarballs", "rootfs.tar.gz"),
 			"29152fd9cadbc92f174815ec642ab3aea98f08f902a4f317ec037f8fe60e40c3",
 			[]string{
 				"test_tar_gz1",
@@ -873,7 +883,7 @@ func TestExtractRootfsTar(t *testing.T) {
 		},
 		{
 			"xz",
-			filepath.Join("testdata", "rootfs_tarballs", "rootfs.tar.xz"),
+			filepath.Join(wd, "testdata", "rootfs_tarballs", "rootfs.tar.xz"),
 			"e3708f1d98ccea0e0c36843d9576580505ee36d523bfcf78b0f73a035ae9a14e",
 			[]string{
 				"test_tar_xz1",
@@ -882,7 +892,7 @@ func TestExtractRootfsTar(t *testing.T) {
 		},
 		{
 			"bz2",
-			filepath.Join("testdata", "rootfs_tarballs", "rootfs.tar.bz2"),
+			filepath.Join(wd, "testdata", "rootfs_tarballs", "rootfs.tar.bz2"),
 			"a1180a73b652d85d7330ef21d433b095363664f2f808363e67f798fae15abf0c",
 			[]string{
 				"test_tar_bz1",
@@ -891,7 +901,7 @@ func TestExtractRootfsTar(t *testing.T) {
 		},
 		{
 			"zst",
-			filepath.Join("testdata", "rootfs_tarballs", "rootfs.tar.zst"),
+			filepath.Join(wd, "testdata", "rootfs_tarballs", "rootfs.tar.zst"),
 			"5fb00513f84e28225a3155fd78c59a6a923b222e1c125aab35bbfd4091281829",
 			[]string{
 				"test_tar_zstd1",
@@ -908,20 +918,18 @@ func TestExtractRootfsTar(t *testing.T) {
 			var stateMachine ClassicStateMachine
 			stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 			stateMachine.parent = &stateMachine
-			absTarPath, err := filepath.Abs(tc.rootfsTar)
-			asserter.AssertErrNil(err, true)
 			stateMachine.ImageDef = imagedefinition.ImageDefinition{
 				Architecture: getHostArch(),
 				Series:       getHostSuite(),
 				Rootfs: &imagedefinition.Rootfs{
 					Tarball: &imagedefinition.Tarball{
-						TarballURL: fmt.Sprintf("file://%s", absTarPath),
+						TarballURL: fmt.Sprintf("file://%s", tc.rootfsTar),
 					},
 				},
 			}
 
 			// need workdir set up for this
-			err = stateMachine.makeTemporaryDirectories()
+			err := stateMachine.makeTemporaryDirectories()
 			asserter.AssertErrNil(err, true)
 
 			err = stateMachine.extractRootfsTar()
@@ -986,9 +994,9 @@ func TestFailedExtractRootfsTar(t *testing.T) {
 
 		// use a tarball that doesn't exist to trigger a failure in computing
 		// the SHA256 sum
-		stateMachine.ImageDef.Rootfs.Tarball.TarballURL = "fakefile"
+		stateMachine.ImageDef.Rootfs.Tarball.TarballURL = "file:///fakefile"
 		err = stateMachine.extractRootfsTar()
-		asserter.AssertErrContains(err, "Error opening file \"fakefile\" to calculate SHA256 sum")
+		asserter.AssertErrContains(err, "Error opening file \"/fakefile\" to calculate SHA256 sum")
 		os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
 	})
 }

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -812,7 +812,7 @@ func manualAddGroup(addGroupInterfaces interface{}, targetDir string, debug bool
 	addGroupSlice := reflect.ValueOf(addGroupInterfaces)
 	for i := 0; i < addGroupSlice.Len(); i++ {
 		addGroup := addGroupSlice.Index(i).Interface().(*imagedefinition.AddGroup)
-		addGroupCmd := execCommand("chroot", targetDir, "groupadd", addGroup.GroupName)
+		addGroupCmd := execCommand("chroot", targetDir, "addgroup", addGroup.GroupName)
 		debugStatement := fmt.Sprintf("Adding group \"%s\"\n", addGroup.GroupName)
 		if addGroup.GroupID != "" {
 			addGroupCmd.Args = append(addGroupCmd.Args, []string{"--gid", addGroup.GroupID}...)
@@ -836,7 +836,7 @@ func manualAddUser(addUserInterfaces interface{}, targetDir string, debug bool) 
 	addUserSlice := reflect.ValueOf(addUserInterfaces)
 	for i := 0; i < addUserSlice.Len(); i++ {
 		addUser := addUserSlice.Index(i).Interface().(*imagedefinition.AddUser)
-		addUserCmd := execCommand("chroot", targetDir, "useradd", addUser.UserName)
+		addUserCmd := execCommand("chroot", targetDir, "adduser", addUser.UserName)
 		debugStatement := fmt.Sprintf("Adding user \"%s\"\n", addUser.UserName)
 		if addUser.UserID != "" {
 			addUserCmd.Args = append(addUserCmd.Args, []string{"--uid", addUser.UserID}...)

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -812,7 +812,7 @@ func manualAddGroup(addGroupInterfaces interface{}, targetDir string, debug bool
 	addGroupSlice := reflect.ValueOf(addGroupInterfaces)
 	for i := 0; i < addGroupSlice.Len(); i++ {
 		addGroup := addGroupSlice.Index(i).Interface().(*imagedefinition.AddGroup)
-		addGroupCmd := execCommand("chroot", targetDir, "addgroup", addGroup.GroupName)
+		addGroupCmd := execCommand("chroot", targetDir, "groupadd", addGroup.GroupName)
 		debugStatement := fmt.Sprintf("Adding group \"%s\"\n", addGroup.GroupName)
 		if addGroup.GroupID != "" {
 			addGroupCmd.Args = append(addGroupCmd.Args, []string{"--gid", addGroup.GroupID}...)
@@ -836,7 +836,7 @@ func manualAddUser(addUserInterfaces interface{}, targetDir string, debug bool) 
 	addUserSlice := reflect.ValueOf(addUserInterfaces)
 	for i := 0; i < addUserSlice.Len(); i++ {
 		addUser := addUserSlice.Index(i).Interface().(*imagedefinition.AddUser)
-		addUserCmd := execCommand("chroot", targetDir, "adduser", addUser.UserName)
+		addUserCmd := execCommand("chroot", targetDir, "useradd", addUser.UserName)
 		debugStatement := fmt.Sprintf("Adding user \"%s\"\n", addUser.UserName)
 		if addUser.UserID != "" {
 			addUserCmd.Args = append(addUserCmd.Args, []string{"--uid", addUser.UserID}...)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap1~beta8
+version: 3.0+snap1~beta10
 grade: stable
 confinement: classic
 base: core20


### PR DESCRIPTION
Relative file paths weren't previously working due to some wackiness in the URL package. I've changed the logic to not depend on the net/url package any longer and now relative file paths are working.