### PR TITLE
FR-3102 add compression support for rootfs tarball artifacts

### DIFF
--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -294,6 +294,26 @@ func CreateTarArchive(src, dest, compression string, verbose, debug bool) error 
 	if debug {
 		tarCommand.Args = append(tarCommand.Args, "--verbose")
 	}
+	// set up any compression arguments
+	switch compression {
+	case "uncompressed":
+		break
+	case "bzip2":
+		tarCommand.Args = append(tarCommand.Args, "--bzip2")
+		break
+	case "gzip":
+		tarCommand.Args = append(tarCommand.Args, "--gzip")
+		break
+	case "xz":
+		tarCommand.Args = append(tarCommand.Args, "--xz")
+		break
+	case "zstd":
+		tarCommand.Args = append(tarCommand.Args, "--zstd")
+		break
+	default:
+		return fmt.Errorf("Unknown compression type: \"%s\"", compression)
+	}
+
 	tarOutput := SetCommandOutput(&tarCommand, debug)
 	if err := tarCommand.Run(); err != nil {
 		return fmt.Errorf("Error running \"tar\" command \"%s\". "+

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2634,10 +2634,32 @@ func TestGenerateRootfsTarball(t *testing.T) {
 	testCases := []struct {
 		name    string // the name will double as the compression type
 		tarPath string
+		fileType string
 	}{
 		{
 			"uncompressed",
 			"test_generate_rootfs_tarball.tar",
+			"tar archive",
+		},
+		{
+			"bzip2",
+			"test_generate_rootfs_tarball.tar.bz2",
+			"bzip2 compressed data",
+		},
+		{
+			"gzip",
+			"test_generate_rootfs_tarball.tar.gz",
+			"gzip compressed data",
+		},
+		{
+			"xz",
+			"test_generate_rootfs_tarball.tar.xz",
+			"XZ compressed data",
+		},
+		{
+			"zstd",
+			"test_generate_rootfs_tarball.tar.zst",
+			"Zstandard compressed data",
 		},
 	}
 	for _, tc := range testCases {
@@ -2673,6 +2695,15 @@ func TestGenerateRootfsTarball(t *testing.T) {
 			_, err = os.Stat(filepath.Join(stateMachine.stateMachineFlags.WorkDir, tc.tarPath))
 			if err != nil {
 				t.Errorf("File %s should be in workdir, but is missing", tc.tarPath)
+			}
+
+			fullPath := filepath.Join(stateMachine.commonFlags.OutputDir, tc.tarPath)
+			fileCommand := *exec.Command("file", fullPath)
+			cmdOutput, err := fileCommand.CombinedOutput()
+			asserter.AssertErrNil(err, true)
+			if !strings.Contains(string(cmdOutput), tc.fileType) {
+				t.Errorf("File \"%s\" is the wrong file type. Expected \"%s\" but got \"%s\"",
+					fullPath, tc.fileType, string(cmdOutput))
 			}
 		})
 	}


### PR DESCRIPTION
Tests are currently broken pending a bugfix included in a separate PR.