### PR TITLE
Use the correct file name

### DIFF
--- a/cmd/ubuntu-image/main.go
+++ b/cmd/ubuntu-image/main.go
@@ -24,7 +24,7 @@ var imageType string = ""
 var stateMachineLongDesc = `Options for controlling the internal state machine.
 Other than -w, these options are mutually exclusive. When -u or -t is given,
 the state machine can be resumed later with -r, but -w must be given in that
-case since the state is saved in a .ubuntu-image.gob file in the working directory.`
+case since the state is saved in a ubuntu-image.gob file in the working directory.`
 
 func executeStateMachine(commonOpts *commands.CommonOpts, stateMachineOpts *commands.StateMachineOpts, ubuntuImageCommand *commands.UbuntuImageCommand) {
 	// Set up the state machine

--- a/ubuntu-image.rst
+++ b/ubuntu-image.rst
@@ -220,7 +220,7 @@ These are some options for controlling this state machine.  Other than
 ``--workdir``, these options are mutually exclusive.  When ``--until`` or
 ``--thru`` is given, the state machine can be resumed later with ``--resume``,
 but ``--workdir`` must be given in that case since the state is saved in a
-``.ubuntu-image.pck`` file in the working directory.
+``ubuntu-image.gob`` file in the working directory.
 
 -w DIRECTORY, --workdir DIRECTORY
     The working directory in which to download and unpack all the source files


### PR DESCRIPTION
Hi, 

If I understand corrrectly
- `.ubuntu-image.pck` is not used anymore, so I replace it with `ubuntu-image.gob` in `ubuntu-image.rst`
- it should be `ubuntu-image.gob` instead of `.ubuntu-image.gob` in `cmd/ubuntu-image/main.go`
