### PR TITLE
FR-2302 use model if provided, only include ca-certificates if ppas are being used

### DIFF
--- a/internal/imagedefinition/README.rst
+++ b/internal/imagedefinition/README.rst
@@ -38,6 +38,7 @@ The following specification defines what is supported in the YAML:
          # The values for these environment variables are sourced
          # from this image definition file. For pre-built
          # gadget trees this must be a local path.
+         # The URI must begin with either http://, https://, or file://
          url: <string>
          # The type of gadget tree source. Currently supported values
          # are git, directory, and prebuilt. When git is used the url
@@ -52,7 +53,7 @@ The following specification defines what is supported in the YAML:
          # Defaults to "main"
          branch: <string> (optional)
        # A path to a model assertion to use when pre-seeding snaps
-       # in the image.
+       # in the image. Must be a local file URI beginning with file://
        model-assertion: <string> (optional)
        # Defines parameters needed to build the rootfs for a classic
        # image. Currently only building from a seed is supported.
@@ -88,7 +89,8 @@ The following specification defines what is supported in the YAML:
          # to be installed in the image.
          seed: (exactly 1 of archive-tasks, seed or tarball must be specified)
              # A list of git, bzr, or http locations from which to
-             # retrieve the seeds.
+             # retrieve the seeds. Must be a web address, local file paths
+             # are not supported
              urls: (required if seed dict is specified)
                - <string>
                - <string>
@@ -108,7 +110,8 @@ The following specification defines what is supported in the YAML:
          # an uncompressed tar archive or a tar archive with one of the
          # following compression types: bzip2, gzip, xz, zstd.
          tarball: (exactly 1 of archive-tasks, seed or tarball must be specified)
-             # The path to the tarball. Can be a local path or an URL.
+             # The path to the tarball. Currently only local paths beginning with
+             # file:// are supported
              url: <string> (required if tarball dict is specified)
              # URL to the gpg signature to verify the tarball against.
              gpg: <string> (optional)

--- a/internal/imagedefinition/image_definition.go
+++ b/internal/imagedefinition/image_definition.go
@@ -21,11 +21,11 @@ type ImageDefinition struct {
 	Series         string         `yaml:"series"          json:"Series"`
 	Kernel         string         `yaml:"kernel"          json:"Kernel,omitempty"`
 	Gadget         *Gadget        `yaml:"gadget"          json:"Gadget,omitempty"`
-	ModelAssertion string         `yaml:"model-assertion" json:"ModelAssertion,omitempty"`
+	ModelAssertion string         `yaml:"model-assertion" json:"ModelAssertion,omitempty" jsonschema:"type=string,format=uri"`
 	Rootfs         *Rootfs        `yaml:"rootfs"          json:"Rootfs"`
 	Customization  *Customization `yaml:"customization"   json:"Customization,omitempty"`
 	Artifacts      *Artifact      `yaml:"artifacts"       json:"Artifacts"`
-	Class          string         `yaml:"class"           json:"Class" jsonschema:"enum=preinstalled,enum=cloud,enum=installer"`
+	Class          string         `yaml:"class"           json:"Class"                    jsonschema:"enum=preinstalled,enum=cloud,enum=installer"`
 }
 
 // Gadget defines the gadget section of the image definition file

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -982,7 +982,7 @@ func (stateMachine *StateMachine) preseedClassicImage() error {
 	}
 
 	imageOpts.Classic = true
-	imageOpts.ModelFile = classicStateMachine.ImageDef.ModelAssertion
+	imageOpts.ModelFile = strings.TrimPrefix(classicStateMachine.ImageDef.ModelAssertion, "file://")
 	imageOpts.Architecture = classicStateMachine.ImageDef.Architecture
 	imageOpts.PrepareDir = classicStateMachine.tempDirs.chroot
 	imageOpts.Customizations = *new(image.Customizations)

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -581,7 +581,7 @@ func (stateMachine *StateMachine) installPackages() error {
 	var installPackagesCmds []*exec.Cmd
 
 	// mount some necessary partitions from the host in the chroot
-	mounts := []string{"/dev", "/proc", "/sys", "/run"}
+	mounts := []string{"/dev", "/proc", "/sys"}
 	var umounts []*exec.Cmd
 	for _, mount := range mounts {
 		mountCmd, umountCmd := mountFromHost(stateMachine.tempDirs.chroot, mount)

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -581,7 +581,7 @@ func (stateMachine *StateMachine) installPackages() error {
 	var installPackagesCmds []*exec.Cmd
 
 	// mount some necessary partitions from the host in the chroot
-	mounts := []string{"/dev", "/proc", "/sys"}
+	mounts := []string{"/dev", "/proc", "/sys", "/run"}
 	var umounts []*exec.Cmd
 	for _, mount := range mounts {
 		mountCmd, umountCmd := mountFromHost(stateMachine.tempDirs.chroot, mount)
@@ -982,6 +982,7 @@ func (stateMachine *StateMachine) preseedClassicImage() error {
 	}
 
 	imageOpts.Classic = true
+	imageOpts.ModelFile = classicStateMachine.ImageDef.ModelAssertion
 	imageOpts.Architecture = classicStateMachine.ImageDef.Architecture
 	imageOpts.PrepareDir = classicStateMachine.tempDirs.chroot
 	imageOpts.Customizations = *new(image.Customizations)

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -59,6 +59,7 @@ func TestYAMLSchemaParsing(t *testing.T) {
 		{"valid_image_definition", "test_raspi.yaml", true, ""},
 		{"invalid_class", "test_bad_class.yaml", false, "Class must be one of the following"},
 		{"invalid_url", "test_bad_url.yaml", false, "Does not match format 'uri'"},
+		{"invalid_model_assertion_url", "test_invalid_model_assertion_url.yaml", false, "Does not match format 'uri'"},
 		{"invalid_ppa_name", "test_bad_ppa_name.yaml", false, "PPAName: Does not match pattern"},
 		{"invalid_ppa_auth", "test_bad_ppa_name.yaml", false, "Auth: Does not match pattern"},
 		{"both_seed_and_tasks", "test_both_seed_and_tasks.yaml", false, "Must validate one and only one schema"},

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -594,8 +594,12 @@ func generateDebootstrapCmd(imageDefinition imagedefinition.ImageDefinition, tar
 	debootstrapCmd := execCommand("debootstrap",
 		"--arch", imageDefinition.Architecture,
 		"--variant=minbase",
-		"--include=ca-certificates", // ca-certificates is needed to use PPAs
 	)
+
+	if imageDefinition.Customization != nil && len(imageDefinition.Customization.ExtraPPAs) > 0 {
+		// ca-certificates is needed to use PPAs
+		debootstrapCmd.Args = append(debootstrapCmd.Args, "--include=ca-certificates")
+	}
 
 	if len(imageDefinition.Rootfs.Components) > 0 {
 		components := strings.Join(imageDefinition.Rootfs.Components, ",")

--- a/internal/statemachine/testdata/image_definitions/test_bad_class.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_bad_class.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   seed:
     urls:

--- a/internal/statemachine/testdata/image_definitions/test_bad_url.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_bad_url.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "This is not a valid URL"
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   seed:
     url: "And this isn't either!"

--- a/internal/statemachine/testdata/image_definitions/test_both_seed_and_tasks.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_both_seed_and_tasks.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   seed:
     urls:

--- a/internal/statemachine/testdata/image_definitions/test_build_gadget.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_build_gadget.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   seed:
     urls:

--- a/internal/statemachine/testdata/image_definitions/test_customization.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_customization.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   seed:
     urls:

--- a/internal/statemachine/testdata/image_definitions/test_extract_rootfs_tar.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_extract_rootfs_tar.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   tarball:
     url: "https://testtar.com/test-tar.tar"

--- a/internal/statemachine/testdata/image_definitions/test_git_gadget_without_url.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_git_gadget_without_url.yaml
@@ -8,7 +8,6 @@ kernel: linux-raspi
 gadget:
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   seed:
     urls:

--- a/internal/statemachine/testdata/image_definitions/test_invalid_model_assertion_url.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_model_assertion_url.yaml
@@ -1,0 +1,42 @@
+name: ubuntu-server-raspi-arm64
+display-name: Ubuntu Server Raspberry Pi arm64
+revision: 2
+architecture: arm64
+series: jammy
+class: preinstalled
+kernel: linux-raspi
+model-assertion: pi-generic.model
+gadget:
+  url: "https://github.com/snapcore/pi-gadget.git"
+  branch: "classic-redesign"
+  type: "git"
+rootfs:
+  seed:
+    urls:
+      - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
+    branch: jammy
+    names:
+      - server
+      - minimal
+      - standard
+      - cloud-image
+      - ubuntu-server-raspi
+customization:
+  cloud-init:
+    user-data: |
+      chpasswd:
+        expire: true
+        users:
+          - name: ubuntu
+            password: ubuntu
+            type: text
+  extra-packages:
+    - name: ubuntu-minimal
+    - name: linux-firmware-raspi
+    - name: pi-bluetooth
+artifacts:
+  img:
+    -
+      name: raspi.img
+  manifest:
+    name: raspi.manifest

--- a/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_copy.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_copy.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: "classic"
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   archive: ubuntu
   mirror: "http://ports.ubuntu.com/ubuntu/"

--- a/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_touch_file.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_touch_file.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: "classic"
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   archive: ubuntu
   mirror: "http://ports.ubuntu.com/ubuntu/"

--- a/internal/statemachine/testdata/image_definitions/test_missing_name.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_missing_name.yaml
@@ -8,7 +8,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   seed:
     urls:

--- a/internal/statemachine/testdata/image_definitions/test_prebuilt_gadget.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_prebuilt_gadget.yaml
@@ -8,7 +8,6 @@ kernel: linux-raspi
 gadget:
   url: "file://test.tar"
   type: "directory"
-model-assertion: pi-generic.model
 rootfs:
   seed:
     urls:

--- a/internal/statemachine/testdata/image_definitions/test_prebuilt_rootfs_extras.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_prebuilt_rootfs_extras.yaml
@@ -8,7 +8,6 @@ kernel: linux-raspi
 gadget:
   url: "file://test.tar"
   type: "directory"
-model-assertion: pi-generic.model
 rootfs:
   tarball:
     url: "file://test.tar"

--- a/internal/statemachine/testdata/image_definitions/test_private_ppa_without_fingerprint.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_private_ppa_without_fingerprint.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   seed:
     urls:

--- a/internal/statemachine/testdata/image_definitions/test_raspi.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_raspi.yaml
@@ -9,7 +9,7 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: "classic-redesign"
   type: "git"
-#model-assertion: pi-generic.model
+model-assertion: file://pi-generic.model
 rootfs:
   archive: ubuntu
   components:

--- a/internal/statemachine/testdata/image_definitions/test_rootfs_seed.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_rootfs_seed.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   seed:
     urls:

--- a/internal/statemachine/testdata/image_definitions/test_rootfs_tasks.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_rootfs_tasks.yaml
@@ -9,7 +9,6 @@ gadget:
   url: "https://github.com/snapcore/pi-gadget.git"
   branch: classic
   type: "git"
-model-assertion: pi-generic.model
 rootfs:
   archive-tasks:
     - ubuntu-server-minimal

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap1~beta12
+version: 3.0+snap1~beta13
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
This PR has two miscellaneous fixes so far. First is adding "/run" to the list of mountpoints. When building base tarballs I noticed there was stuff in "/run" that shouldn't be there. Adding it as a mountpoint solves the issue.

The other issue is that we were accidentally dropping the model assertion if one was present.

This is only a draft as I'm still looking for other issues while creating the rootfs tarballs, and think I might need to convert the model assertion to a file URI.