### PR TITLE
FR-3331 clean up run file tree

### DIFF
--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -611,13 +611,15 @@ func (stateMachine *StateMachine) installPackages() error {
 		if mount.fromHost {
 			mountCmd, umountCmd = mountFromHost(stateMachine.tempDirs.chroot, mount.dest)
 		} else {
-			mountCmd, umountCmd, err = mountNewFS(stateMachine.tempDirs.chroot,
+			mountCmd, umountCmd, err = mountTempFS(stateMachine.tempDirs.chroot,
 				stateMachine.tempDirs.scratch,
 				mount.dest,
 			)
 			if err != nil {
-				return fmt.Errorf("Error creating temporary directory for mountpoint: \"%s\"",
-					err.Error())
+				return fmt.Errorf("Error mounting temporary directory for mountpoint \"%s\": \"%s\"",
+					mount.dest,
+					err.Error(),
+				)
 
 			}
 		}

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -607,10 +607,10 @@ func (stateMachine *StateMachine) installPackages() error {
 	var umounts []*exec.Cmd
 	for _, mount := range mountPoints {
 		var mountCmd, umountCmd *exec.Cmd
-		var err error
 		if mount.fromHost {
 			mountCmd, umountCmd = mountFromHost(stateMachine.tempDirs.chroot, mount.dest)
 		} else {
+			var err error
 			mountCmd, umountCmd, err = mountTempFS(stateMachine.tempDirs.chroot,
 				stateMachine.tempDirs.scratch,
 				mount.dest,

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2371,7 +2371,7 @@ func TestFailedInstallPackages(t *testing.T) {
 			osMkdirTemp = os.MkdirTemp
 		}()
 		err := stateMachine.installPackages()
-		asserter.AssertErrContains(err, "Error creating temporary directory")
+		asserter.AssertErrContains(err, "Error mounting temporary directory for mountpoint")
 		osMkdirTemp = os.MkdirTemp
 
 		// Setup the exec.Command mock

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2365,7 +2365,7 @@ func TestFailedInstallPackages(t *testing.T) {
 			},
 		}
 
-		// mock os.MkdirTemp to cause a failure in mountNewFS
+		// mock os.MkdirTemp to cause a failure in mountTempFS
 		osMkdirTemp = mockMkdirTemp
 		defer func() {
 			osMkdirTemp = os.MkdirTemp

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2365,13 +2365,22 @@ func TestFailedInstallPackages(t *testing.T) {
 			},
 		}
 
+		// mock os.MkdirTemp to cause a failure in mountNewFS
+		osMkdirTemp = mockMkdirTemp
+		defer func() {
+			osMkdirTemp = os.MkdirTemp
+		}()
+		err := stateMachine.installPackages()
+		asserter.AssertErrContains(err, "Error creating temporary directory")
+		osMkdirTemp = os.MkdirTemp
+
 		// Setup the exec.Command mock
 		testCaseName = "TestFailedInstallPackages"
 		execCommand = fakeExecCommand
 		defer func() {
 			execCommand = exec.Command
 		}()
-		err := stateMachine.installPackages()
+		err = stateMachine.installPackages()
 		asserter.AssertErrContains(err, "Error running command")
 		execCommand = exec.Command
 

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -756,8 +756,8 @@ func mountFromHost(targetDir, mountpoint string) (mountCmd, umountCmd *exec.Cmd)
 	return mountCmd, umountCmd
 }
 
-// mountNewFS creates a new filesystem and mounts it at the specified location
-func mountNewFS(targetDir, scratchDir, mountpoint string) (mountCmd, umountCmd *exec.Cmd, err error) {
+// mountTempFS creates a temporary directory and mounts it at the specified location
+func mountTempFS(targetDir, scratchDir, mountpoint string) (mountCmd, umountCmd *exec.Cmd, err error) {
 	tempDir, err := osMkdirTemp(scratchDir, strings.Trim(mountpoint, "/"))
 	if err != nil {
 		return nil, nil, err

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -756,6 +756,17 @@ func mountFromHost(targetDir, mountpoint string) (mountCmd, umountCmd *exec.Cmd)
 	return mountCmd, umountCmd
 }
 
+// mountNewFS creates a new filesystem and mounts it at the specified location
+func mountNewFS(targetDir, scratchDir, mountpoint string) (mountCmd, umountCmd *exec.Cmd, err error) {
+	tempDir, err := osMkdirTemp(scratchDir, strings.Trim(mountpoint, "/"))
+	if err != nil {
+		return nil, nil, err
+	}
+	mountCmd = execCommand("mount", "--bind", tempDir, filepath.Join(targetDir, mountpoint))
+	umountCmd = execCommand("umount", filepath.Join(targetDir, mountpoint))
+	return mountCmd, umountCmd, nil
+}
+
 // manualCopyFile copies a file into the chroot
 func manualCopyFile(copyFileInterfaces interface{}, targetDir string, debug bool) error {
 	copyFileSlice := reflect.ValueOf(copyFileInterfaces)

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1265,3 +1265,19 @@ func TestCheckCustomizationSteps(t *testing.T) {
 		})
 	}
 }
+
+// TestFailedMountNewFS tests failures in the mountNewFS function
+func TestFailedMountNewFS(t *testing.T) {
+	t.Run("test_failed_mount_new_fs", func(t *testing.T) {
+		asserter := helper.Asserter{T: t}
+
+		// mock os.MkdirTemp
+		osMkdirTemp = mockMkdirTemp
+		defer func() {
+			osMkdirTemp = os.MkdirTemp
+		}()
+		_, _, err := mountNewFS("", "", "")
+		asserter.AssertErrContains(err, "Test error")
+		osMkdirTemp = os.MkdirTemp
+	})
+}

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1266,8 +1266,8 @@ func TestCheckCustomizationSteps(t *testing.T) {
 	}
 }
 
-// TestFailedMountNewFS tests failures in the mountTempFS function
-func TestFailedMountNewFS(t *testing.T) {
+// TestFailedMountTempFS tests failures in the mountTempFS function
+func TestFailedMountTempFS(t *testing.T) {
 	t.Run("test_failed_mount_new_fs", func(t *testing.T) {
 		asserter := helper.Asserter{T: t}
 

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1266,7 +1266,7 @@ func TestCheckCustomizationSteps(t *testing.T) {
 	}
 }
 
-// TestFailedMountNewFS tests failures in the mountNewFS function
+// TestFailedMountNewFS tests failures in the mountTempFS function
 func TestFailedMountNewFS(t *testing.T) {
 	t.Run("test_failed_mount_new_fs", func(t *testing.T) {
 		asserter := helper.Asserter{T: t}
@@ -1276,7 +1276,7 @@ func TestFailedMountNewFS(t *testing.T) {
 		defer func() {
 			osMkdirTemp = os.MkdirTemp
 		}()
-		_, _, err := mountNewFS("", "", "")
+		_, _, err := mountTempFS("", "", "")
 		asserter.AssertErrContains(err, "Test error")
 		osMkdirTemp = os.MkdirTemp
 	})

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap1~beta13
+version: 3.0+snap1~beta14
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
While creating ubuntu-image base tarballs, we noticed that there were some files getting placed in `/run` that shouldn't be in the final image. While this was harmless because it would just get mounted over, it's still messy so we want to clean it up.

I investigated livecd-rootfs/live-build to see how they handle this, and they create a new directory to mount to `/run` in the chroot. I have adjusted ubuntu-image to do the same.