### PR TITLE
Copy host /etc/resolv.conf to chroot when necessary

### DIFF
--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -420,7 +420,7 @@ func BackupAndCopyResolvConf(chroot string) error {
 	}
 	dest = src
 	src = filepath.Join("/etc", "resolv.conf")
-	if err := osutil.CopyFile(src, dest, 0); err != nil {
+	if err := osutil.CopyFile(src, dest, osutil.CopyFlagDefault); err != nil {
 		return fmt.Errorf("Error copying file \"%s\" to \"%s\": %s", src, dest, err.Error())
 	}
 	return nil

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/canonical/ubuntu-image/internal/commands"
 	"github.com/invopop/jsonschema"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/xeipuuv/gojsonschema"
 )
 

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -7,11 +7,13 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 
 	"github.com/canonical/ubuntu-image/internal/commands"
 	"github.com/invopop/jsonschema"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -406,4 +408,18 @@ func CheckTags(searchStruct interface{}, tag string) (string, error) {
 	}
 	// no true value found
 	return "", nil
+}
+
+func BackupAndCopyResolvConf(chroot string) error {
+	src := filepath.Join(chroot, "etc", "resolv.conf")
+	dest := filepath.Join(chroot, "etc", "resolv.conf.tmp")
+	if err := os.Rename(src, dest); err != nil {
+		return fmt.Errorf("Error moving file \"%s\" to \"%s\": %s", src, dest, err.Error())
+	}
+	dest = src
+	src = filepath.Join("/etc", "resolv.conf")
+	if err := osutil.CopyFile(src, dest, 0); err != nil {
+		return fmt.Errorf("Error copying file \"%s\" to \"%s\": %s", src, dest, err.Error())
+	}
+	return nil
 }

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -410,6 +410,8 @@ func CheckTags(searchStruct interface{}, tag string) (string, error) {
 	return "", nil
 }
 
+// BackupAndCopyResolvConf creates a backup of /etc/resolv.conf in a chroot
+// and copies the contents from the host system into the chroot
 func BackupAndCopyResolvConf(chroot string) error {
 	src := filepath.Join(chroot, "etc", "resolv.conf")
 	dest := filepath.Join(chroot, "etc", "resolv.conf.tmp")

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -413,6 +413,10 @@ func CheckTags(searchStruct interface{}, tag string) (string, error) {
 // BackupAndCopyResolvConf creates a backup of /etc/resolv.conf in a chroot
 // and copies the contents from the host system into the chroot
 func BackupAndCopyResolvConf(chroot string) error {
+	if osutil.FileExists(filepath.Join(chroot, "etc", "resolv.conf.tmp")) {
+		// already backed up/copied so do nothing
+		return nil
+	}
 	src := filepath.Join(chroot, "etc", "resolv.conf")
 	dest := filepath.Join(chroot, "etc", "resolv.conf.tmp")
 	if err := os.Rename(src, dest); err != nil {
@@ -422,6 +426,19 @@ func BackupAndCopyResolvConf(chroot string) error {
 	src = filepath.Join("/etc", "resolv.conf")
 	if err := osutil.CopyFile(src, dest, osutil.CopyFlagDefault); err != nil {
 		return fmt.Errorf("Error copying file \"%s\" to \"%s\": %s", src, dest, err.Error())
+	}
+	return nil
+}
+
+// RestoreResolvConf restores the resolv.conf in the chroot from the
+// version that was backed up by BackupAndCopyResolvConf
+func RestoreResolvConf(chroot string) error {
+	if osutil.FileExists(filepath.Join(chroot, "etc", "resolv.conf.tmp")) {
+		src := filepath.Join(chroot, "etc", "resolv.conf.tmp")
+		dest := filepath.Join(chroot, "etc", "resolv.conf")
+		if err := os.Rename(src, dest); err != nil {
+			return fmt.Errorf("Error moving file \"%s\" to \"%s\": %s", src, dest, err.Error())
+		}
 	}
 	return nil
 }

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -18,7 +18,6 @@ import (
 	"github.com/canonical/ubuntu-image/internal/imagedefinition"
 	"github.com/invopop/jsonschema"
 	"github.com/snapcore/snapd/image"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 	"github.com/xeipuuv/gojsonschema"
@@ -564,11 +563,9 @@ func (stateMachine *StateMachine) installPackages() error {
 	classicStateMachine = stateMachine.parent.(*ClassicStateMachine)
 
 	// copy /etc/resolv.conf from the host system into the chroot
-	if !osutil.FileExists(filepath.Join(classicStateMachine.tempDirs.chroot, "etc", "resolv.conf.tmp")) {
-		err := helperBackupAndCopyResolvConf(classicStateMachine.tempDirs.chroot)
-		if err != nil {
-			return fmt.Errorf("Error setting up /etc/resolv.conf in the chroot: \"%s\"", err.Error())
-		}
+	err := helperBackupAndCopyResolvConf(classicStateMachine.tempDirs.chroot)
+	if err != nil {
+		return fmt.Errorf("Error setting up /etc/resolv.conf in the chroot: \"%s\"", err.Error())
 	}
 
 	// if any extra packages are specified, install them alongside the seeded packages
@@ -943,11 +940,9 @@ func (stateMachine *StateMachine) manualCustomization() error {
 	classicStateMachine = stateMachine.parent.(*ClassicStateMachine)
 
 	// copy /etc/resolv.conf from the host system into the chroot if it hasn't already been done
-	if !osutil.FileExists(filepath.Join(classicStateMachine.tempDirs.chroot, "etc", "resolv.conf.tmp")) {
-		err := helperBackupAndCopyResolvConf(classicStateMachine.tempDirs.chroot)
-		if err != nil {
-			return fmt.Errorf("Error setting up /etc/resolv.conf in the chroot: \"%s\"", err.Error())
-		}
+	err := helperBackupAndCopyResolvConf(classicStateMachine.tempDirs.chroot)
+	if err != nil {
+		return fmt.Errorf("Error setting up /etc/resolv.conf in the chroot: \"%s\"", err.Error())
 	}
 
 	type customizationHandler struct {
@@ -1067,12 +1062,9 @@ func (stateMachine *StateMachine) populateClassicRootfsContents() error {
 	classicStateMachine = stateMachine.parent.(*ClassicStateMachine)
 
 	// if we backed up resolv.conf then restore it here
-	if osutil.FileExists(filepath.Join(stateMachine.tempDirs.chroot, "etc", "resolv.conf.tmp")) {
-		src := filepath.Join(classicStateMachine.tempDirs.chroot, "etc", "resolv.conf.tmp")
-		dest := filepath.Join(classicStateMachine.tempDirs.chroot, "etc", "resolv.conf")
-		if err := osRename(src, dest); err != nil {
-			return fmt.Errorf("Error moving file \"%s\" to \"%s\": %s", src, dest, err.Error())
-		}
+	err := helperRestoreResolvConf(classicStateMachine.tempDirs.chroot)
+	if err != nil {
+		return fmt.Errorf("Error restoring /etc/resolv.conf in the chroot: \"%s\"", err.Error())
 	}
 
 	files, err := ioutilReadDir(stateMachine.tempDirs.chroot)

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -1576,14 +1576,14 @@ func TestFailedPopulateClassicRootfsContents(t *testing.T) {
 		_, err = os.Create(filepath.Join(stateMachine.tempDirs.chroot, "etc", "resolv.conf.tmp"))
 		asserter.AssertErrNil(err, true)
 
-		// mock os.Rename
-		osRename = mockRename
+		// mock helper.RestoreResolvConf
+		helperRestoreResolvConf = mockRestoreResolvConf
 		defer func() {
-			osRename = os.Rename
+			helperRestoreResolvConf = helper.RestoreResolvConf
 		}()
 		err = stateMachine.populateClassicRootfsContents()
-		asserter.AssertErrContains(err, "Error moving file")
-		osRename = os.Rename
+		asserter.AssertErrContains(err, "Error restoring /etc/resolv.conf")
+		helperRestoreResolvConf = helper.RestoreResolvConf
 	})
 }
 

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -38,6 +38,7 @@ var helperSetDefaults = helper.SetDefaults
 var helperCheckEmptyFields = helper.CheckEmptyFields
 var helperCheckTags = helper.CheckTags
 var helperBackupAndCopyResolvConf = helper.BackupAndCopyResolvConf
+var helperRestoreResolvConf = helper.RestoreResolvConf
 var ioutilReadAll = ioutil.ReadAll
 var ioutilReadDir = ioutil.ReadDir
 var ioutilReadFile = ioutil.ReadFile

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -37,6 +37,7 @@ var helperCopyBlob = helper.CopyBlob
 var helperSetDefaults = helper.SetDefaults
 var helperCheckEmptyFields = helper.CheckEmptyFields
 var helperCheckTags = helper.CheckTags
+var helperBackupAndCopyResolvConf = helper.BackupAndCopyResolvConf
 var ioutilReadAll = ioutil.ReadAll
 var ioutilReadDir = ioutil.ReadDir
 var ioutilReadFile = ioutil.ReadFile

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -66,6 +66,9 @@ func mockCheckTags(interface{}, string) (string, error) {
 func mockBackupAndCopyResolvConf(string) error {
 	return fmt.Errorf("Test Error")
 }
+func mockRestoreResolvConf(string) error {
+	return fmt.Errorf("Test Error")
+}
 func mockCopyBlobSuccess([]string) error {
 	return nil
 }

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -63,6 +63,9 @@ func mockCheckEmptyFields(interface{}, *gojsonschema.Result, *jsonschema.Schema)
 func mockCheckTags(interface{}, string) (string, error) {
 	return "", fmt.Errorf("Test Error")
 }
+func mockBackupAndCopyResolvConf(string) error {
+	return fmt.Errorf("Test Error")
+}
 func mockCopyBlobSuccess([]string) error {
 	return nil
 }

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap1~beta14
+version: 3.0+snap1~beta15
 grade: stable
 confinement: classic
 base: core20


### PR DESCRIPTION
There was a bug related to /etc/resolv.conf being a symlink to a file that didn't exists. It turns out livecd-rootfs/live-build handle this by copying the contents /etc/resolv.conf from the host system into the chroot, and restoring it at the end. I have chosen to restore this file right before staging the final rootfs. That way, any customization scripts, etc will have a working resolv.conf. Any state that may require network access in the chroot first checks if there is a backup, and if not creates one and copies the host /etc/resolv.conf into the chroot.