### PR TITLE
FR-3546 Preseed classic images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 require github.com/ulikunitz/xz v0.5.10 // indirect
 
 require (
-	github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2 // indirect
-	github.com/snapcore/snapd v0.0.0-20230110165810-bb2514455dea
+	github.com/snapcore/secboot v0.0.0-20230119174011-57239c9f324a // indirect
+	github.com/snapcore/snapd v0.0.0-20230224164448-b0848d7c7799
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,11 +112,11 @@ github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8/go.mod h1:Z6z3sf12
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
 github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2 h1:nETXPg0CiJrMAwC2gqkcam9BiBWYGvTsSYRfrjOz2Kg=
 github.com/snapcore/go-gettext v0.0.0-20201130093759-38740d1bd3d2/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
-github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2 h1:sPC5tmNoJ6H8Pu9OHZiYP1YIAlG98Nm44CYS9nliPz0=
-github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
+github.com/snapcore/secboot v0.0.0-20230119174011-57239c9f324a h1:MwEn6ADhO9DYtqRnat71TOYxcNxBVUeqfDCBtrYcu7Y=
+github.com/snapcore/secboot v0.0.0-20230119174011-57239c9f324a/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
-github.com/snapcore/snapd v0.0.0-20230110165810-bb2514455dea h1:sKRBg9nQLoYJ11ySb7EHOdYJFTBoKXHDr8aLZcFet2Q=
-github.com/snapcore/snapd v0.0.0-20230110165810-bb2514455dea/go.mod h1:smkkw6QWeTo9l8t9gxqLcbFzBOPZpeJxa2bHZWWcTYY=
+github.com/snapcore/snapd v0.0.0-20230224164448-b0848d7c7799 h1:SqHJhBJDIcg42aG60Lv/Y8buLSo3QAjn2rWPTT3hYfo=
+github.com/snapcore/snapd v0.0.0-20230224164448-b0848d7c7799/go.mod h1:6f8/YFmYLQ3H4ySp21aAZ/LMlps3De9xPwCI3KfDr9k=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -1032,9 +1032,9 @@ func (stateMachine *StateMachine) prepareClassicImage() error {
 				preseed.Stdout = oldPreseedStdout
 			}()
 		}
-		err = preseed.ClassicReset(stateMachine.tempDirs.chroot)
+		err = preseedClassicReset(stateMachine.tempDirs.chroot)
 		if err != nil {
-			return fmt.Errorf("error resetting preseeding in the chroot")
+			return fmt.Errorf("Error resetting preseeding in the chroot")
 		}
 	}
 

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -22,6 +22,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/timings"
 )
 
 // validateInput ensures that command line flags for the state machine are valid. These
@@ -875,10 +877,17 @@ func manualAddUser(addUserInterfaces interface{}, targetDir string, debug bool) 
 // the image definition's customization struct to be passed in and
 // uses struct tags to identify which state must be added
 func checkCustomizationSteps(searchStruct interface{}, tag string) (extraStates []stateFunc) {
-	possibleStateFunc := map[string]stateFunc{
-		"add_extra_ppas":         stateFunc{"add_extra_ppas", (*StateMachine).addExtraPPAs},
-		"install_extra_packages": stateFunc{"install_extra_packages", (*StateMachine).installPackages},
-		"install_extra_snaps":    stateFunc{"install_extra_snaps", (*StateMachine).preseedClassicImage},
+	possibleStateFunc := map[string][]stateFunc{
+		"add_extra_ppas": []stateFunc{
+			stateFunc{"add_extra_ppas", (*StateMachine).addExtraPPAs},
+		},
+		"install_extra_packages": []stateFunc{
+			stateFunc{"install_extra_packages", (*StateMachine).installPackages},
+		},
+		"install_extra_snaps": []stateFunc{
+			stateFunc{"install_extra_snaps", (*StateMachine).prepareClassicImage},
+			stateFunc{"preseed_extra_snaps", (*StateMachine).preseedClassicImage},
+		},
 	}
 	value := reflect.ValueOf(searchStruct)
 	elem := value.Elem()
@@ -888,9 +897,39 @@ func checkCustomizationSteps(searchStruct interface{}, tag string) (extraStates 
 			tags := elem.Type().Field(i).Tag
 			tagValue, hasTag := tags.Lookup(tag)
 			if hasTag {
-				extraStates = append(extraStates, possibleStateFunc[tagValue])
+				extraStates = append(extraStates, possibleStateFunc[tagValue]...)
 			}
 		}
 	}
 	return extraStates
+}
+
+// getPreseedsnaps returns a slice of the snaps that were preseeded in a chroot
+// and their channels
+func getPreseededSnaps(rootfs string) (seededSnaps map[string]string, err error) {
+	// seededSnaps maps the snap name and channel that was seeded
+	seededSnaps = make(map[string]string)
+
+	// open the seed and run LoadAssertions and LoadMeta to get a list of snaps
+	snapdDir := filepath.Join(rootfs, "var", "lib", "snapd")
+	seedDir := filepath.Join(snapdDir, "seed")
+	preseed, err := seedOpen(seedDir, "")
+	if err != nil {
+		return seededSnaps, err
+	}
+	measurer := timings.New(nil)
+	if err := preseed.LoadAssertions(nil, nil); err != nil {
+		return seededSnaps, err
+	}
+	if err := preseed.LoadMeta(seed.AllModes, nil, measurer); err != nil {
+		return seededSnaps, err
+	}
+
+	// iterate over the snaps in the seed and add them to the list
+	preseed.Iter(func(sn *seed.Snap) error {
+		seededSnaps[sn.SnapName()] = sn.Channel
+		return nil
+	})
+
+	return seededSnaps, nil
 }

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -20,6 +21,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/mkfs"
+	"github.com/snapcore/snapd/seed"
 )
 
 // TestMaxOffset tests the functionality of the maxOffset function
@@ -1280,4 +1282,62 @@ func TestFailedMountTempFS(t *testing.T) {
 		asserter.AssertErrContains(err, "Test error")
 		osMkdirTemp = os.MkdirTemp
 	})
+}
+
+// TestFailedGetPreseededSnaps tests various failure scenarios in the getPreseededSnaps function
+func TestFailedGetPreseededSnaps(t *testing.T) {
+        t.Run("test_failed_remove_preseeding", func(t *testing.T) {
+                asserter := helper.Asserter{T: t}
+                var stateMachine StateMachine
+                stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+
+                // need workdir set up for this
+                err := stateMachine.makeTemporaryDirectories()
+                asserter.AssertErrNil(err, true)
+
+                seedDir := filepath.Join(stateMachine.tempDirs.rootfs, "var", "lib", "snapd", "seed")
+                err = os.MkdirAll(seedDir, 0755)
+                asserter.AssertErrNil(err, true)
+
+                // call "snap prepare image" to preseed the filesystem.
+                // Doing the preseed at the time of the test allows it to
+                // run on each architecture and keeps the github repository
+                // free of large .snap files
+                snapPrepareImage := *exec.Command("snap", "prepare-image", "--arch=amd64",
+                        "--classic", "--snap=core20", "--snap=snapd", "--snap=lxd",
+                        filepath.Join("testdata", "modelAssertionClassic"),
+                        stateMachine.tempDirs.rootfs)
+                err = snapPrepareImage.Run()
+                asserter.AssertErrNil(err, true)
+
+                // mock seed.Open
+                seedOpen = mockSeedOpen
+                defer func() {
+                        seedOpen = seed.Open
+                }()
+                _, err = getPreseededSnaps(stateMachine.tempDirs.rootfs)
+                asserter.AssertErrContains(err, "Test error")
+                seedOpen = seed.Open
+
+                // move the model from var/lib/snapd/seed/assertions to cause an error
+                err = os.Rename(filepath.Join(seedDir, "assertions", "model"),
+                        filepath.Join(stateMachine.tempDirs.rootfs, "model"))
+                asserter.AssertErrNil(err, true)
+                _, err = getPreseededSnaps(stateMachine.tempDirs.rootfs)
+                asserter.AssertErrContains(err, "seed must have a model assertion")
+                err = os.Rename(filepath.Join(stateMachine.tempDirs.rootfs, "model"),
+                        filepath.Join(seedDir, "assertions", "model"))
+
+                // move seed.yaml to cause an error in LoadMeta
+                err = os.Rename(filepath.Join(seedDir, "seed.yaml"),
+                        filepath.Join(seedDir, "seed.yaml.bak"))
+                asserter.AssertErrNil(err, true)
+                _, err = getPreseededSnaps(stateMachine.tempDirs.rootfs)
+                asserter.AssertErrContains(err, "no seed metadata")
+                err = os.Rename(filepath.Join(seedDir, "seed.yaml.bak"),
+                        filepath.Join(seedDir, "seed.yaml"))
+                asserter.AssertErrNil(err, true)
+
+                os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
+        })
 }

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1286,58 +1286,58 @@ func TestFailedMountTempFS(t *testing.T) {
 
 // TestFailedGetPreseededSnaps tests various failure scenarios in the getPreseededSnaps function
 func TestFailedGetPreseededSnaps(t *testing.T) {
-        t.Run("test_failed_remove_preseeding", func(t *testing.T) {
-                asserter := helper.Asserter{T: t}
-                var stateMachine StateMachine
-                stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+	t.Run("test_failed_remove_preseeding", func(t *testing.T) {
+		asserter := helper.Asserter{T: t}
+		var stateMachine StateMachine
+		stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 
-                // need workdir set up for this
-                err := stateMachine.makeTemporaryDirectories()
-                asserter.AssertErrNil(err, true)
+		// need workdir set up for this
+		err := stateMachine.makeTemporaryDirectories()
+		asserter.AssertErrNil(err, true)
 
-                seedDir := filepath.Join(stateMachine.tempDirs.rootfs, "var", "lib", "snapd", "seed")
-                err = os.MkdirAll(seedDir, 0755)
-                asserter.AssertErrNil(err, true)
+		seedDir := filepath.Join(stateMachine.tempDirs.rootfs, "var", "lib", "snapd", "seed")
+		err = os.MkdirAll(seedDir, 0755)
+		asserter.AssertErrNil(err, true)
 
-                // call "snap prepare image" to preseed the filesystem.
-                // Doing the preseed at the time of the test allows it to
-                // run on each architecture and keeps the github repository
-                // free of large .snap files
-                snapPrepareImage := *exec.Command("snap", "prepare-image", "--arch=amd64",
-                        "--classic", "--snap=core20", "--snap=snapd", "--snap=lxd",
-                        filepath.Join("testdata", "modelAssertionClassic"),
-                        stateMachine.tempDirs.rootfs)
-                err = snapPrepareImage.Run()
-                asserter.AssertErrNil(err, true)
+		// call "snap prepare image" to preseed the filesystem.
+		// Doing the preseed at the time of the test allows it to
+		// run on each architecture and keeps the github repository
+		// free of large .snap files
+		snapPrepareImage := *exec.Command("snap", "prepare-image", "--arch=amd64",
+			"--classic", "--snap=core20", "--snap=snapd", "--snap=lxd",
+			filepath.Join("testdata", "modelAssertionClassic"),
+			stateMachine.tempDirs.rootfs)
+		err = snapPrepareImage.Run()
+		asserter.AssertErrNil(err, true)
 
-                // mock seed.Open
-                seedOpen = mockSeedOpen
-                defer func() {
-                        seedOpen = seed.Open
-                }()
-                _, err = getPreseededSnaps(stateMachine.tempDirs.rootfs)
-                asserter.AssertErrContains(err, "Test error")
-                seedOpen = seed.Open
+		// mock seed.Open
+		seedOpen = mockSeedOpen
+		defer func() {
+			seedOpen = seed.Open
+		}()
+		_, err = getPreseededSnaps(stateMachine.tempDirs.rootfs)
+		asserter.AssertErrContains(err, "Test error")
+		seedOpen = seed.Open
 
-                // move the model from var/lib/snapd/seed/assertions to cause an error
-                err = os.Rename(filepath.Join(seedDir, "assertions", "model"),
-                        filepath.Join(stateMachine.tempDirs.rootfs, "model"))
-                asserter.AssertErrNil(err, true)
-                _, err = getPreseededSnaps(stateMachine.tempDirs.rootfs)
-                asserter.AssertErrContains(err, "seed must have a model assertion")
-                err = os.Rename(filepath.Join(stateMachine.tempDirs.rootfs, "model"),
-                        filepath.Join(seedDir, "assertions", "model"))
+		// move the model from var/lib/snapd/seed/assertions to cause an error
+		err = os.Rename(filepath.Join(seedDir, "assertions", "model"),
+			filepath.Join(stateMachine.tempDirs.rootfs, "model"))
+		asserter.AssertErrNil(err, true)
+		_, err = getPreseededSnaps(stateMachine.tempDirs.rootfs)
+		asserter.AssertErrContains(err, "seed must have a model assertion")
+		err = os.Rename(filepath.Join(stateMachine.tempDirs.rootfs, "model"),
+			filepath.Join(seedDir, "assertions", "model"))
 
-                // move seed.yaml to cause an error in LoadMeta
-                err = os.Rename(filepath.Join(seedDir, "seed.yaml"),
-                        filepath.Join(seedDir, "seed.yaml.bak"))
-                asserter.AssertErrNil(err, true)
-                _, err = getPreseededSnaps(stateMachine.tempDirs.rootfs)
-                asserter.AssertErrContains(err, "no seed metadata")
-                err = os.Rename(filepath.Join(seedDir, "seed.yaml.bak"),
-                        filepath.Join(seedDir, "seed.yaml"))
-                asserter.AssertErrNil(err, true)
+		// move seed.yaml to cause an error in LoadMeta
+		err = os.Rename(filepath.Join(seedDir, "seed.yaml"),
+			filepath.Join(seedDir, "seed.yaml.bak"))
+		asserter.AssertErrNil(err, true)
+		_, err = getPreseededSnaps(stateMachine.tempDirs.rootfs)
+		asserter.AssertErrContains(err, "no seed metadata")
+		err = os.Rename(filepath.Join(seedDir, "seed.yaml.bak"),
+			filepath.Join(seedDir, "seed.yaml"))
+		asserter.AssertErrNil(err, true)
 
-                os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
-        })
+		os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
+	})
 }

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -22,6 +22,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/image"
+	"github.com/snapcore/snapd/image/preseed"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/mkfs"
 	"github.com/snapcore/snapd/seed"
@@ -61,6 +62,7 @@ var diskfsCreate = diskfs.Create
 var randRead = rand.Read
 var seedOpen = seed.Open
 var imagePrepare = image.Prepare
+var preseedClassicReset = preseed.ClassicReset
 var httpGet = http.Get
 var jsonUnmarshal = json.Unmarshal
 var yamlMarshal = yaml.Marshal

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -213,6 +213,8 @@ func TestExecHelperProcess(t *testing.T) {
 	case "TestGenerateFilelist":
 		fmt.Fprint(os.Stdout, "/root\n/home\n/var")
 		break
+	case "TestFailedPreseedClassicImage":
+		fallthrough
 	case "TestFailedMakeQcow2Image":
 		fallthrough
 	case "TestFailedGeneratePackageManifest":

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -148,6 +148,9 @@ func mockSeedOpen(seedDir, label string) (seed.Seed, error) {
 func mockImagePrepare(*image.Options) error {
 	return fmt.Errorf("Test Error")
 }
+func mockPreseedClassicReset(string) error {
+	return fmt.Errorf("Test Error")
+}
 func mockGet(string) (*http.Response, error) {
 	return nil, fmt.Errorf("Test Error")
 }

--- a/internal/statemachine/testdata/image_definitions/test_amd64.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_amd64.yaml
@@ -37,6 +37,8 @@ customization:
     -
       name: hello
       channel: candidate
+    -
+      name: core
   extra-ppas:
     -
       name: "canonical-foundations/ubuntu-image"


### PR DESCRIPTION
This PR adds support for preseeding classic images. As discussed with the snapd team, there's no reason to ever leave a classic image without preseeding, so it is always done.