### PR TITLE
Remove usage of deprecated ioutil package

### DIFF
--- a/cmd/ubuntu-image/main.go
+++ b/cmd/ubuntu-image/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/canonical/ubuntu-image/internal/commands"
@@ -99,7 +99,7 @@ func main() {
 			case flags.ErrHelp:
 				restoreStdout()
 				restoreStderr()
-				readStdout, err := ioutil.ReadAll(stdout)
+				readStdout, err := io.ReadAll(stdout)
 				if err != nil {
 					fmt.Printf("Error reading from stdout: %s\n", err.Error())
 					osExit(1)
@@ -113,7 +113,7 @@ func main() {
 				if !stateMachineOpts.Resume && !commonOpts.Version {
 					restoreStdout()
 					restoreStderr()
-					readStderr, err := ioutil.ReadAll(stderr)
+					readStderr, err := io.ReadAll(stderr)
 					if err != nil {
 						fmt.Printf("Error reading from stderr: %s\n", err.Error())
 						osExit(1)

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"os/exec"
@@ -400,7 +400,7 @@ func (stateMachine *StateMachine) buildGadgetTree() error {
 		sourceURL, _ := url.Parse(classicStateMachine.ImageDef.Gadget.GadgetURL)
 
 		// copy the source tree to the workdir
-		files, err := ioutilReadDir(sourceURL.Path)
+		files, err := osReadDir(sourceURL.Path)
 		if err != nil {
 			return fmt.Errorf("Error reading gadget tree: %s", err.Error())
 		}
@@ -462,7 +462,7 @@ func (stateMachine *StateMachine) prepareGadgetTree() error {
 	} else {
 		gadgetTree = filepath.Join(classicStateMachine.tempDirs.scratch, "gadget")
 	}
-	files, err := ioutilReadDir(gadgetTree)
+	files, err := osReadDir(gadgetTree)
 	if err != nil {
 		return fmt.Errorf("Error reading gadget tree: %s", err.Error())
 	}
@@ -1062,7 +1062,7 @@ func (stateMachine *StateMachine) preseedClassicImage() error {
 	// verbose or greater logging
 	if !stateMachine.commonFlags.Debug && !stateMachine.commonFlags.Verbose {
 		oldImageStdout := image.Stdout
-		image.Stdout = ioutil.Discard
+		image.Stdout = io.Discard
 		defer func() {
 			image.Stdout = oldImageStdout
 		}()
@@ -1087,7 +1087,7 @@ func (stateMachine *StateMachine) populateClassicRootfsContents() error {
 		return fmt.Errorf("Error restoring /etc/resolv.conf in the chroot: \"%s\"", err.Error())
 	}
 
-	files, err := ioutilReadDir(stateMachine.tempDirs.chroot)
+	files, err := osReadDir(stateMachine.tempDirs.chroot)
 	if err != nil {
 		return fmt.Errorf("Error reading unpack/chroot dir: %s", err.Error())
 	}
@@ -1102,7 +1102,7 @@ func (stateMachine *StateMachine) populateClassicRootfsContents() error {
 	if classicStateMachine.ImageDef.Customization != nil {
 		if len(classicStateMachine.ImageDef.Customization.Fstab) == 0 {
 			fstabPath := filepath.Join(classicStateMachine.tempDirs.rootfs, "etc", "fstab")
-			fstabBytes, err := ioutilReadFile(fstabPath)
+			fstabBytes, err := osReadFile(fstabPath)
 			if err == nil {
 				if !strings.Contains(string(fstabBytes), "LABEL=writable") {
 					re := regexp.MustCompile(`(?m:^LABEL=\S+\s+/\s+(.*)$)`)
@@ -1110,7 +1110,7 @@ func (stateMachine *StateMachine) populateClassicRootfsContents() error {
 					if !strings.Contains(string(newContents), "LABEL=writable") {
 						newContents = []byte("LABEL=writable   /    ext4   defaults    0 0")
 					}
-					err := ioutilWriteFile(fstabPath, newContents, 0644)
+					err := osWriteFile(fstabPath, newContents, 0644)
 					if err != nil {
 						return fmt.Errorf("Error writing to fstab: %s", err.Error())
 					}

--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -76,7 +76,7 @@ func (stateMachine *StateMachine) loadGadgetYaml() error {
 	}
 
 	// read in the gadget.yaml as bytes, because snapd expects it that way
-	gadgetYamlBytes, err := ioutilReadFile(stateMachine.YamlFilePath)
+	gadgetYamlBytes, err := osReadFile(stateMachine.YamlFilePath)
 	if err != nil {
 		return fmt.Errorf("Error reading gadget.yaml bytes: %s", err.Error())
 	}

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -4,7 +4,6 @@ package statemachine
 import (
 	"bytes"
 	"crypto/rand"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -210,14 +209,14 @@ func TestFailedLoadGadgetYaml(t *testing.T) {
 		asserter.AssertErrContains(err, "Error copying gadget.yaml")
 		osutilCopyFile = osutil.CopyFile
 
-		// mock ioutilReadFile
-		ioutilReadFile = mockReadFile
+		// mock osReadFile
+		osReadFile = mockReadFile
 		defer func() {
-			ioutilReadFile = ioutil.ReadFile
+			osReadFile = os.ReadFile
 		}()
 		err = stateMachine.loadGadgetYaml()
 		asserter.AssertErrContains(err, "Error reading gadget.yaml bytes")
-		ioutilReadFile = ioutil.ReadFile
+		osReadFile = os.ReadFile
 
 		// now test with the invalid yaml file
 		stateMachine.YamlFilePath = filepath.Join("testdata",
@@ -467,7 +466,7 @@ func TestPopulateBootfsContents(t *testing.T) {
 		asserter.AssertErrNil(err, true)
 
 		// populate unpack
-		files, _ := ioutil.ReadDir(filepath.Join("testdata", "gadget_tree"))
+		files, _ := os.ReadDir(filepath.Join("testdata", "gadget_tree"))
 		for _, srcFile := range files {
 			srcFile := filepath.Join("testdata", "gadget_tree", srcFile.Name())
 			osutilCopySpecialFile(srcFile, filepath.Join(stateMachine.tempDirs.unpack, "gadget"))
@@ -513,7 +512,7 @@ func TestPopulateBootfsContentsPiboot(t *testing.T) {
 		asserter.AssertErrNil(err, true)
 
 		// populate unpack
-		files, _ := ioutil.ReadDir(filepath.Join("testdata", "gadget_tree_piboot"))
+		files, _ := os.ReadDir(filepath.Join("testdata", "gadget_tree_piboot"))
 		for _, srcFile := range files {
 			srcFile := filepath.Join("testdata", "gadget_tree_piboot", srcFile.Name())
 			osutilCopySpecialFile(srcFile, filepath.Join(stateMachine.tempDirs.unpack, "gadget"))
@@ -559,7 +558,7 @@ func TestFailedPopulateBootfsContents(t *testing.T) {
 		os.MkdirAll(stateMachine.tempDirs.volumes, 0755)
 
 		// populate unpack
-		files, _ := ioutil.ReadDir(filepath.Join("testdata", "gadget_tree"))
+		files, _ := os.ReadDir(filepath.Join("testdata", "gadget_tree"))
 		for _, srcFile := range files {
 			srcFile := filepath.Join("testdata", "gadget_tree", srcFile.Name())
 			osutilCopySpecialFile(srcFile, filepath.Join(stateMachine.tempDirs.unpack, "gadget"))
@@ -638,7 +637,7 @@ func TestPopulatePreparePartitions(t *testing.T) {
 		os.MkdirAll(stateMachine.tempDirs.volumes, 0755)
 
 		// populate unpack
-		files, _ := ioutil.ReadDir(filepath.Join("testdata", "gadget_tree"))
+		files, _ := os.ReadDir(filepath.Join("testdata", "gadget_tree"))
 		for _, srcFile := range files {
 			srcFile := filepath.Join("testdata", "gadget_tree", srcFile.Name())
 			osutilCopySpecialFile(srcFile, filepath.Join(stateMachine.tempDirs.unpack, "gadget"))
@@ -667,7 +666,7 @@ func TestPopulatePreparePartitions(t *testing.T) {
 		// check the contents of part0.img
 		partImg := filepath.Join(stateMachine.tempDirs.volumes,
 			"pc", "part0.img")
-		partImgBytes, _ := ioutil.ReadFile(partImg)
+		partImgBytes, _ := os.ReadFile(partImg)
 		dataBytes := make([]byte, 440)
 		// partImg should consist of these 11 bytes and 429 null bytes
 		copy(dataBytes[:11], []byte{84, 69, 83, 84, 32, 70, 73, 76, 69, 10})
@@ -702,7 +701,7 @@ func TestFailedPopulatePreparePartitions(t *testing.T) {
 		os.MkdirAll(stateMachine.tempDirs.volumes, 0755)
 
 		// populate unpack
-		files, _ := ioutil.ReadDir(filepath.Join("testdata", "gadget_tree"))
+		files, _ := os.ReadDir(filepath.Join("testdata", "gadget_tree"))
 		for _, srcFile := range files {
 			srcFile := filepath.Join("testdata", "gadget_tree", srcFile.Name())
 			osutilCopySpecialFile(srcFile, filepath.Join(stateMachine.tempDirs.unpack, "gadget"))
@@ -762,7 +761,7 @@ func TestEmptyPartPopulatePreparePartitions(t *testing.T) {
 		os.MkdirAll(stateMachine.tempDirs.volumes, 0755)
 
 		// populate unpack
-		files, _ := ioutil.ReadDir(filepath.Join("testdata", "gadget_tree"))
+		files, _ := os.ReadDir(filepath.Join("testdata", "gadget_tree"))
 		for _, srcFile := range files {
 			srcFile := filepath.Join("testdata", "gadget_tree", srcFile.Name())
 			osutilCopySpecialFile(srcFile, filepath.Join(stateMachine.tempDirs.unpack, "gadget"))
@@ -791,7 +790,7 @@ func TestEmptyPartPopulatePreparePartitions(t *testing.T) {
 		// check part2.img, it should be empty and have a 4K size
 		partImg := filepath.Join(stateMachine.tempDirs.volumes,
 			"pc", "part2.img")
-		partImgBytes, _ := ioutil.ReadFile(partImg)
+		partImgBytes, _ := os.ReadFile(partImg)
 		// these are all zeroes
 		dataBytes := make([]byte, 4096)
 		if !bytes.Equal(partImgBytes, dataBytes) {
@@ -831,7 +830,7 @@ func TestMakeDiskPartitionSchemes(t *testing.T) {
 			defer os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
 
 			// also set up an output directory
-			outDir, err := ioutil.TempDir("/tmp", "ubuntu-image-")
+			outDir, err := os.MkdirTemp("/tmp", "ubuntu-image-")
 			asserter.AssertErrNil(err, true)
 			defer os.RemoveAll(outDir)
 			stateMachine.commonFlags.OutputDir = outDir
@@ -861,7 +860,7 @@ func TestMakeDiskPartitionSchemes(t *testing.T) {
 			os.MkdirAll(stateMachine.tempDirs.volumes, 0755)
 
 			// populate unpack
-			files, _ := ioutil.ReadDir(filepath.Join("testdata", "gadget_tree"))
+			files, _ := os.ReadDir(filepath.Join("testdata", "gadget_tree"))
 			for _, srcFile := range files {
 				srcFile := filepath.Join("testdata", "gadget_tree", srcFile.Name())
 				osutil.CopySpecialFile(srcFile, filepath.Join(stateMachine.tempDirs.unpack, "gadget"))
@@ -912,7 +911,7 @@ func TestFailedMakeDisk(t *testing.T) {
 		defer os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
 
 		// also set up an output directory
-		outDir, err := ioutil.TempDir("/tmp", "ubuntu-image-")
+		outDir, err := os.MkdirTemp("/tmp", "ubuntu-image-")
 		asserter.AssertErrNil(err, true)
 		defer os.RemoveAll(outDir)
 		stateMachine.commonFlags.OutputDir = outDir
@@ -939,7 +938,7 @@ func TestFailedMakeDisk(t *testing.T) {
 		os.MkdirAll(stateMachine.tempDirs.volumes, 0755)
 
 		// populate unpack
-		files, _ := ioutil.ReadDir(filepath.Join("testdata", "gadget_tree"))
+		files, _ := os.ReadDir(filepath.Join("testdata", "gadget_tree"))
 		for _, srcFile := range files {
 			srcFile := filepath.Join("testdata", "gadget_tree", srcFile.Name())
 			osutilCopySpecialFile(srcFile, filepath.Join(stateMachine.tempDirs.unpack, "gadget"))
@@ -1114,7 +1113,7 @@ func TestImageSizeFlag(t *testing.T) {
 			//defer os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
 
 			// also set up an output directory
-			outDir, err := ioutil.TempDir("/tmp", "ubuntu-image-")
+			outDir, err := os.MkdirTemp("/tmp", "ubuntu-image-")
 			asserter.AssertErrNil(err, true)
 			//defer os.RemoveAll(outDir)
 			stateMachine.commonFlags.OutputDir = outDir
@@ -1137,7 +1136,7 @@ func TestImageSizeFlag(t *testing.T) {
 			os.MkdirAll(stateMachine.tempDirs.volumes, 0755)
 
 			// populate unpack
-			files, _ := ioutil.ReadDir(tc.gadgetTree)
+			files, _ := os.ReadDir(tc.gadgetTree)
 			for _, srcFile := range files {
 				srcFile := filepath.Join(tc.gadgetTree, srcFile.Name())
 				osutil.CopySpecialFile(srcFile, filepath.Join(stateMachine.tempDirs.unpack, "gadget"))

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -114,7 +114,7 @@ func (stateMachine *StateMachine) handleLkBootloader(volume *gadget.Volume) erro
 	if err != nil && !os.IsExist(err) {
 		return fmt.Errorf("Failed to create gadget dir: %s", err.Error())
 	}
-	files, err := ioutilReadDir(bootDir)
+	files, err := osReadDir(bootDir)
 	if err != nil {
 		return fmt.Errorf("Error reading lk bootloader dir: %s", err.Error())
 	}
@@ -205,7 +205,7 @@ func (stateMachine *StateMachine) copyStructureContent(volume *gadget.Volume,
 			}
 		}
 		// check if any content exists in unpack
-		contentFiles, err := ioutilReadDir(contentRoot)
+		contentFiles, err := osReadDir(contentRoot)
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("Error listing contents of volume \"%s\": %s",
 				contentRoot, err.Error())
@@ -256,7 +256,7 @@ func (stateMachine *StateMachine) handleSecureBoot(volume *gadget.Volume, target
 		return fmt.Errorf("Error creating ubuntu dir: %s", err.Error())
 	}
 
-	files, err := ioutilReadDir(bootDir)
+	files, err := osReadDir(bootDir)
 	if err != nil {
 		return fmt.Errorf("Error reading boot dir: %s", err.Error())
 	}
@@ -273,7 +273,7 @@ func (stateMachine *StateMachine) handleSecureBoot(volume *gadget.Volume, target
 
 // WriteSnapManifest generates a snap manifest based on the contents of the selected snapsDir
 func WriteSnapManifest(snapsDir string, outputPath string) error {
-	files, err := ioutilReadDir(snapsDir)
+	files, err := osReadDir(snapsDir)
 	if err != nil {
 		// As per previous ubuntu-image manifest generation, we skip generating
 		// manifests for non-existent/invalid paths
@@ -700,7 +700,7 @@ func importPPAKeys(ppa *imagedefinition.PPA, tmpGPGDir, keyFilePath string, debu
 				ppa.PPAName, err.Error())
 		}
 
-		body, err := ioutilReadAll(resp.Body)
+		body, err := ioReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("Error reading signing key for ppa \"%s\": %s",
 				ppa.PPAName, err.Error())

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -69,14 +69,14 @@ func TestFailedHandleSecureBoot(t *testing.T) {
 		asserter.AssertErrContains(err, "Error creating ubuntu dir")
 		osMkdirAll = os.MkdirAll
 
-		// mock ioutil.ReadDir
-		ioutilReadDir = mockReadDir
+		// mock os.ReadDir
+		osReadDir = mockReadDir
 		defer func() {
-			ioutilReadDir = ioutil.ReadDir
+			osReadDir = os.ReadDir
 		}()
 		err = stateMachine.handleSecureBoot(volume, stateMachine.tempDirs.rootfs)
 		asserter.AssertErrContains(err, "Error reading boot dir")
-		ioutilReadDir = ioutil.ReadDir
+		osReadDir = os.ReadDir
 
 		// mock os.Rename
 		osRename = mockRename
@@ -121,14 +121,14 @@ func TestFailedHandleSecureBootPiboot(t *testing.T) {
 		asserter.AssertErrContains(err, "Error creating ubuntu dir")
 		osMkdirAll = os.MkdirAll
 
-		// mock ioutil.ReadDir
-		ioutilReadDir = mockReadDir
+		// mock os.ReadDir
+		osReadDir = mockReadDir
 		defer func() {
-			ioutilReadDir = ioutil.ReadDir
+			osReadDir = os.ReadDir
 		}()
 		err = stateMachine.handleSecureBoot(volume, stateMachine.tempDirs.rootfs)
 		asserter.AssertErrContains(err, "Error reading boot dir")
-		ioutilReadDir = ioutil.ReadDir
+		osReadDir = os.ReadDir
 
 		// mock os.Rename
 		osRename = mockRename
@@ -212,14 +212,14 @@ func TestFailedHandleLkBootloader(t *testing.T) {
 		asserter.AssertErrContains(err, "Failed to create gadget dir")
 		osMkdir = os.Mkdir
 
-		// mock ioutil.ReadDir
-		ioutilReadDir = mockReadDir
+		// mock os.ReadDir
+		osReadDir = mockReadDir
 		defer func() {
-			ioutilReadDir = ioutil.ReadDir
+			osReadDir = os.ReadDir
 		}()
 		err = stateMachine.handleLkBootloader(volume)
 		asserter.AssertErrContains(err, "Error reading lk bootloader dir")
-		ioutilReadDir = ioutil.ReadDir
+		osReadDir = os.ReadDir
 
 		// mock osutil.CopySpecialFile
 		osutilCopySpecialFile = mockCopySpecialFile
@@ -290,15 +290,15 @@ func TestFailedCopyStructureContent(t *testing.T) {
 		asserter.AssertErrContains(err, "Error zeroing image file")
 		helperCopyBlob = helper.CopyBlob
 
-		// mock ioutil.ReadDir
-		ioutilReadDir = mockReadDir
+		// mock os.ReadDir
+		osReadDir = mockReadDir
 		defer func() {
-			ioutilReadDir = ioutil.ReadDir
+			osReadDir = os.ReadDir
 		}()
 		err = stateMachine.copyStructureContent(volume, rootfsStruct, 0, "",
 			filepath.Join("/tmp", uuid.NewString()+".img"))
 		asserter.AssertErrContains(err, "Error listing contents of volume")
-		ioutilReadDir = ioutil.ReadDir
+		osReadDir = os.ReadDir
 
 		// mock gadget.MkfsWithContent
 		mkfsMakeWithContent = mockMkfsWithContent
@@ -466,7 +466,7 @@ func TestWarningRootfsSizeTooSmall(t *testing.T) {
 
 		// restore stdout and check that the warning was printed
 		restoreStdout()
-		readStdout, err := ioutil.ReadAll(stdout)
+		readStdout, err := io.ReadAll(stdout)
 		asserter.AssertErrNil(err, true)
 
 		if !strings.Contains(string(readStdout), "WARNING: rootfs structure size 0 B smaller than actual rootfs contents") {
@@ -1062,14 +1062,14 @@ func TestFailedImportPPAKeys(t *testing.T) {
 		asserter.AssertErrContains(err, "Error getting signing key")
 		httpGet = http.Get
 
-		// mock ioutil.ReadAll
-		ioutilReadAll = mockReadAll
+		// mock io.ReadAll
+		ioReadAll = mockReadAll
 		defer func() {
-			ioutilReadAll = ioutil.ReadAll
+			ioReadAll = io.ReadAll
 		}()
 		err = importPPAKeys(ppa, tmpGPGDir, keyFilePath, false)
 		asserter.AssertErrContains(err, "Error reading signing key")
-		ioutilReadAll = ioutil.ReadAll
+		ioReadAll = io.ReadAll
 
 		// mock json.Unmarshal
 		jsonUnmarshal = mockUnmarshal
@@ -1107,7 +1107,7 @@ func TestManifestRevisionFormat(t *testing.T) {
 
 		expectedManifestData := "test1 123\ntest2 456\ntest3 789\n"
 
-		manifestData, err := ioutil.ReadFile(manifestOutput)
+		manifestData, err := os.ReadFile(manifestOutput)
 		asserter.AssertErrNil(err, true)
 
 		if string(manifestData) != expectedManifestData {

--- a/internal/statemachine/snap_states.go
+++ b/internal/statemachine/snap_states.go
@@ -2,7 +2,7 @@ package statemachine
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -59,7 +59,7 @@ func (stateMachine *StateMachine) prepareImage() error {
 	// verbose or greater logging
 	if !stateMachine.commonFlags.Debug && !stateMachine.commonFlags.Verbose {
 		oldImageStdout := image.Stdout
-		image.Stdout = ioutil.Discard
+		image.Stdout = io.Discard
 		defer func() {
 			image.Stdout = oldImageStdout
 		}()
@@ -106,7 +106,7 @@ func (stateMachine *StateMachine) populateSnapRootfsContents() error {
 	}
 
 	// recursively copy the src to dst, skipping /boot for non-seeded images
-	files, err := ioutilReadDir(src)
+	files, err := osReadDir(src)
 	if err != nil {
 		return fmt.Errorf("Error reading unpack dir: %s", err.Error())
 	}

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -7,7 +7,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -39,10 +39,10 @@ var helperCheckEmptyFields = helper.CheckEmptyFields
 var helperCheckTags = helper.CheckTags
 var helperBackupAndCopyResolvConf = helper.BackupAndCopyResolvConf
 var helperRestoreResolvConf = helper.RestoreResolvConf
-var ioutilReadAll = ioutil.ReadAll
-var ioutilReadDir = ioutil.ReadDir
-var ioutilReadFile = ioutil.ReadFile
-var ioutilWriteFile = ioutil.WriteFile
+var ioReadAll = io.ReadAll
+var osReadDir = os.ReadDir
+var osReadFile = os.ReadFile
+var osWriteFile = os.WriteFile
 var osMkdir = os.Mkdir
 var osMkdirAll = os.MkdirAll
 var osMkdirTemp = os.MkdirTemp

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -3,7 +3,6 @@ package statemachine
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -88,8 +87,8 @@ func mockMkfs(typ, img, label string, deviceSize, sectorSize quantity.Size) erro
 func mockReadAll(io.Reader) ([]byte, error) {
 	return []byte{}, fmt.Errorf("Test Error")
 }
-func mockReadDir(string) ([]os.FileInfo, error) {
-	return []os.FileInfo{}, fmt.Errorf("Test Error")
+func mockReadDir(string) ([]os.DirEntry, error) {
+	return []os.DirEntry{}, fmt.Errorf("Test Error")
 }
 func mockReadFile(string) ([]byte, error) {
 	return []byte{}, fmt.Errorf("Test Error")
@@ -343,7 +342,7 @@ func TestDebug(t *testing.T) {
 
 		// restore stdout and check that the debug info was printed
 		restoreStdout()
-		readStdout, err := ioutil.ReadAll(stdout)
+		readStdout, err := io.ReadAll(stdout)
 		asserter.AssertErrNil(err, true)
 
 		if !strings.Contains(string(readStdout), stateMachine.states[0].name) {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap1~beta18
+version: 3.0+snap1~beta19
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
`io/ioutil` has been deprecated since Go 1.16, with all of it's functionality now available through either the `io` or `os` packages. This PR removes any usage of the `io/ioutil` package.