### PR TITLE
statemachine: return error if overlap GPT header or GPT partition table

### DIFF
--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -355,7 +355,10 @@ func (stateMachine *StateMachine) makeDisk() error {
 			}
 
 			// set up the partitions on the device
-			partitionTable := createPartitionTable(volumeName, volume, uint64(stateMachine.SectorSize), stateMachine.IsSeeded)
+			partitionTable, err := createPartitionTable(volumeName, volume, uint64(stateMachine.SectorSize), stateMachine.IsSeeded)
+			if err != nil {
+				return fmt.Errorf("Error partitioning image file: %s", err.Error())
+			}
 
 			// Write the partition table to disk
 			if err := diskImg.Partition(*partitionTable); err != nil {


### PR DESCRIPTION
Hi,

My previous PR has some conflict with ubuntu-image 3.0, so I closed it first then open this new PR after resolve the conflict.

Previously I opened a similiar [PR](https://github.com/snapcore/snapd/pull/12454) in snapd, and recently I found it might be suitable to handle GPT overlapping issue here in ubuntu-image because it is able to know the sector-size

According to UEFI spec:
> If the block size is 512, the First Usable LBA must be greater than or equal to 34 (allowing 1 block for the Protective MBR, 1 block for the Partition Table Header, and 32 blocks for the GPT Partition Entry Array); if the logical block size is 4096, the First Useable LBA must be greater than or equal to 6 (allowing 1 block for the Protective MBR, 1 block for the GPT Header, and 4 blocks for the GPT Partition Entry Array).

Currently if the offset defined in gadget.yaml overlaps the GPT header or GPT partition table, the ubuntu-image will still build an image, but the image is totally not usable, so I think we should return error instead of overwrite any GPT related data, the following are some test that I have done.

---

### Test case 1
Here is the gadget.yaml that will overlap with GPT partition, the offset is 17407, and sector-size is 512
```yaml
volumes:
  test:
    schema: gpt
    bootloader: u-boot
    structure:
      - name: firmware
        offset: 17407
        size: 64M
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        content:
          - image: firmware.img
      - name: bootloaders
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        filesystem: vfat
        filesystem-label: system-boot
        size: 10M
        content:
          - source: configs/
            target: /
```
Here is the partition table for the image built by using ubuntu-image
```sh
$ mmls out/test.img
GUID Partition Table (EFI)
Offset Sector: 0
Units are in 512-byte sectors

      Slot      Start        End          Length       Description
000:  Meta      0000000000   0000000000   0000000001   Safety Table
001:  -------   0000000000   0000000032   0000000033   Unallocated
002:  Meta      0000000001   0000000001   0000000001   GPT Header
003:  Meta      0000000002   0000000033   0000000032   Partition Table
004:  000       0000000033   0000131104   0000131072   firmware
005:  001       0000131105   0000151584   0000020480   bootloaders
006:  002       0000151585   0007144528   0006992944   writable
007:  124       0003194880   41231719608736   41231716413857   
008:  -------   41231719608737   3692961299186534214   3692920067466925478   Unallocated
009:  125       3692961299186534215   3697464897618051072   4503598431516858   䝇䝇ࢼ㍐
```


### Test case 2
Here is the gadget snap that will not overlap with GPT partition table, the offset is 17408, and sector-size is 512
```yaml
volumes:
  test:
    schema: gpt
    bootloader: u-boot
    structure:
      - name: firmware
        offset: 17408
        size: 64M
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        content:
          - image: firmware.img
      - name: bootloaders
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        filesystem: vfat
        filesystem-label: system-boot
        size: 10M
        content:
          - source: configs/
            target: /
```

Here is the partition table for the image built by using ubuntu-image
```
$ mmls out/test.img 
GUID Partition Table (EFI)
Offset Sector: 0
Units are in 512-byte sectors

      Slot      Start        End          Length       Description
000:  Meta      0000000000   0000000000   0000000001   Safety Table
001:  -------   0000000000   0000000033   0000000034   Unallocated
002:  Meta      0000000001   0000000001   0000000001   GPT Header
003:  Meta      0000000002   0000000033   0000000032   Partition Table
004:  000       0000000034   0000131105   0000131072   firmware
005:  001       0000131106   0000151585   0000020480   bootloaders
006:  002       0000151586   0007144517   0006992932   writable
007:  -------   0007144518   0007178239   0000033722   Unallocated
```

### Test case 3
Here is the gadget.yaml that will overlap with GPT partition, the offset is 24575, and sector-size is 4096
```yaml
volumes:
  test:
    schema: gpt
    bootloader: u-boot
    structure:
      - name: firmware
        offset: 24575
        size: 64M
        type: 0C,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        content:
          - image: firmware.img
      - name: ubuntu-seed
        role: system-seed
        filesystem: vfat
        type: 0C,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        size: 1200M
      - name: ubuntu-boot
        role: system-boot
        filesystem: vfat
        type: 0C,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        size: 750M
        content:
          - source: boot.sel
            target: uboot/ubuntu/boot.sel
      - name: ubuntu-save
        role: system-save
        filesystem: ext4
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        size: 32M
      - name: ubuntu-data
        role: system-data
        filesystem: ext4
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        size: 1500M
```
Here is the partition table for the image built by using ubuntu-image
```sh
$ mmls out/test.img 
GUID Partition Table (EFI)
Offset Sector: 0
Units are in 4096-byte sectors

      Slot      Start        End          Length       Description
000:  Meta      0000000000   0000000000   0000000001   Safety Table
001:  -------   0000000000   0000000005   0000000006   Unallocated
002:  Meta      0000000001   0000000001   0000000001   GPT Header
003:  Meta      0000000002   0000000005   0000000004   Partition Table
004:  000       0000000006   0000016389   0000016384   firmware
005:  001       0000016390   0000323589   0000307200   ubuntu-seed
006:  -------   0000323590   474013864260045056   474013864259721467   Unallocated
007:  111       474013864260045057   4111416512631541272   3637402648371496216   疊뺬ද툚햲骵蹣鿼鶪褑ﭟ륟Ά㇃ᅂ棊䲓떮섽㈴튂쐶앜０뙏䬍탁ビ㩄芼͌폗宨➮
008:  -------   787329208074459579   1825067574672665112   1037738366598205534   Unallocated
009:  098       1555384621285035654   787329208074459578   17678688660498975541   藿왯瘈ꩃ⥌⤠輽䯭᧞蟾ཾ䢔촑獑⼵맏輚⨍䦗ᓘ驤臛쓦ᛜ풾蕮줗쓬⢐競关끛
010:  096       1825067574672665113   15495002984991184059   13669935410318518947   ꛿븝ꦞ荇솰놖䴅캧䇷檴^摎膁䞺殸ꣅﻹ㘻䟁碷绬滪鞋涄뎅텀籄䮃
011:  -------   2134375064178454559   13516433803352030744   11382058739173576186   Unallocated
012:  104       2372921042565941382   7230220675389181711   4857299632823240330   ᷏ꖇ褸辶䇫^᧋檪㯳ꅣ肘⬊ゼ≥샳冚㟶掄踢ꕒￖ^鄵訣ꓰ옋ி웩黹螂േ錕
013:  105       3050902190914832570   3494038857408408967   443136666493576398   Ꙃ뛗⥾㶧训뻹퓅ꇦد臽徨藍ꕐ顨퍚ᓭ뿚⭳ꔦ뻉⸲ⱆ휩괔귂듴췱뢬∱
014:  -------   3494038857408408968   3583592951005847761   89554093597438794   Unallocated
015:  106       3583592951005847762   12029846823440904403   8446253872435056642   궝퍢^Ы陟ꇆ뷻ᚳ謱蚩刑怨ꪣ墹筱淓ぷ譯ԒᏍ㟭쿗焫ꏎ堇益ﵤ乫ᰁ^
016:  108       5898631303317974993   17401674149650376246   11503042846332401254   
017:  107       8614790747606953853   17951763192961714284   9336972445354760432   谧峡ස頀鉁툌瑚鿈鳢ᑪ䬸㧠^겊᭯◖쎸혥㨂㓑⟀뎆ᙬ㠔礠䡊볛춎
018:  109       8791407652672027407   11220835708294775617   2429428055622748211   ᇥ贆뤦Ⓚ瓒䦢呖芭멅᧹凋梵˥⍫貸㐾ꟌО韨෾悪韄顧ғुស୯콪皱Ўᣡ
019:  -------   8813259943102593311   14865872653258092336   6052612710155499026   Unallocated
020:  -------   11220835708294775618   11711467986940801331   490632278646025714   Unallocated
021:  102       11711467986940801332   15929490110392391530   4218022123451590199   俈췜ᵥ︆뾙䈓毹ߕ㑒်勃輈^딃뛘嫢隝袑琁⓯㼬苲ⲉᏻ䏳腫솁䔔巛蟺졏
022:  -------   11803468479006767003   16844355049835919670   5040886570829152668   Unallocated
023:  103       11997433506291634337   2134375064178454558   8583685631596371838   ދ㋂㶗傭겿葭㧇㻭汧੧㧔龁ꥨ縂巳℠頝Ţꑻ⇝伶엪ꫳ౿ᕤ潏୹䚬^鐝⩍퍹㝵當
024:  097       13516433803352030745   8813259943102593310   13743570213460114182   麯㪻ö︋ᘨ니틢ᤡ圑Ᏼ윐ጼ㳛⾋郍ⅈ喷ᚾ﹞ᄈ㽣콹휧߉趙ꡰ俪^뿀₡
025:  -------   14266781760454664029   17284105123646654501   3017323363191990473   Unallocated
026:  101       14865872653258092337   11803468479006767002   15384339899458226282   卤䨡髋䰠좙鲠ു舔ഺﲑ燍뾖펱硌나Ფ蹖笢㚯鬈쐞茻ɲ鯧ꢡ㙽๖^䌂ု꼊㤱旮酓쪽
027:  -------   16137837542131246401   18000214407529660915   1862376865398414515   Unallocated
028:  100       16844355049835919671   14266781760454664028   15869170784328295974   誽ᚺ௧쉬䯃ᜄꆉ偿齖嘜꒖䞑^䎊椛襓ඓ屹꾃텐览햚㻕쾱^牚⌁愗孜忮
029:  099       17284105123646654502   16137837542131246400   17300476492194143515   䕬冦鯚哢襰合ꥊ똳嵮膰쐋儉험멷辉ﬣ焤ӻ暖ؑ䀺쩛碂⋯鸙搐ᮕ⽒穝捅ᤨ㣆
030:  110       18000214407529660916   7495451150526574731   7941980816706465432   㵔ꡍ푅椴馞ጐ픍腧留㗮摷䯒摥獭⡰윣蔽ѿ^졺柁穋輚졸炆㨤^天虗큝홓ꛟ莎
```

### Test case 4
Here is the gadget.yaml that will not overlap with GPT partition, the offset is 24576, and sector-size is 4096
```yaml
volumes:
  test:
    schema: gpt
    bootloader: u-boot
    structure:
      - name: firmware
        offset: 24576
        size: 64M
        type: 0C,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        content:
          - image: firmware.img
      - name: ubuntu-seed
        role: system-seed
        filesystem: vfat
        type: 0C,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        size: 1200M
      - name: ubuntu-boot
        role: system-boot
        filesystem: vfat
        type: 0C,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        size: 750M
        content:
          - source: boot.sel
            target: uboot/ubuntu/boot.sel
      - name: ubuntu-save
        role: system-save
        filesystem: ext4
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        size: 32M
      - name: ubuntu-data
        role: system-data
        filesystem: ext4
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        size: 1500M
```
Here is the partition table for the image built by using ubuntu-image
```sh
$ mmls out/test.img 
GUID Partition Table (EFI)
Offset Sector: 0
Units are in 4096-byte sectors

      Slot      Start        End          Length       Description
000:  Meta      0000000000   0000000000   0000000001   Safety Table
001:  -------   0000000000   0000000005   0000000006   Unallocated
002:  Meta      0000000001   0000000001   0000000001   GPT Header
003:  Meta      0000000002   0000000005   0000000004   Partition Table
004:  000       0000000006   0000016389   0000016384   firmware
005:  001       0000016390   0000323589   0000307200   ubuntu-seed
006:  -------   0000323590   0000912127   0000588538   Unallocated
```

I am still pretty new to golang, please let me know if I made any mistake, thanks for spending time review this!
