### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,15 +10,14 @@ base: core22
 source-code: https://github.com/canonical/ubuntu-image
 issues: https://bugs.launchpad.net/ubuntu-image/+filebug
 
-# Force the snap to use fakeroot staged within the snap
-environment:
-  FAKEROOT_FLAGS: "--lib $SNAP/usr/lib/lib-arch/libfakeroot/libfakeroot-tcp.so --faked $SNAP/usr/bin/faked-tcp"
-  PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/sbin:$PATH
-  GCONV_PATH: /snap/core20/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gconv
-
 apps:
   ubuntu-image:
     command: bin/ubuntu-image
+    environment:
+      # Force the snap to use fakeroot staged within the snap
+      FAKEROOT_FLAGS: "--lib $SNAP/usr/lib/lib-arch/libfakeroot/libfakeroot-tcp.so --faked $SNAP/usr/bin/faked-tcp"
+      PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/sbin:$PATH
+      GCONV_PATH: /snap/core20/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gconv
 
 parts:
   ubuntu-image:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,7 +17,7 @@ apps:
       # Force the snap to use fakeroot staged within the snap
       FAKEROOT_FLAGS: "--lib $SNAP/usr/lib/lib-arch/libfakeroot/libfakeroot-tcp.so --faked $SNAP/usr/bin/faked-tcp"
       PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/sbin:$PATH
-      GCONV_PATH: /snap/core20/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gconv
+      GCONV_PATH: /snap/core22/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gconv
 
 parts:
   ubuntu-image:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,10 +34,12 @@ parts:
     stage-packages:
       - fdisk
       - gdisk
+      - mtools
       - fakeroot
       - debootstrap
       - gpg
       - germinate
+      - python3-germinate
     override-build: |
       snapcraftctl build
       # create a symlink /usr/bin/fakeroot -> /usr/bin/fakeroot-tcp

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -40,10 +40,10 @@ parts:
       - germinate
       - python3-germinate
     override-build: |
-      snapcraftctl build
+      craftctl default
       # create a symlink /usr/bin/fakeroot -> /usr/bin/fakeroot-tcp
-      cd $SNAPCRAFT_PART_INSTALL/usr/bin/
+      cd $CRAFT_PART_INSTALL/usr/bin/
       ln -s fakeroot-tcp fakeroot
       # Create a symbolic link to /usr/lib/<arch> where libfakeroot will live
-      cd $SNAPCRAFT_PART_INSTALL/usr/lib/
-      ln -s ${SNAPCRAFT_ARCH_TRIPLET} lib-arch
+      cd $CRAFT_PART_INSTALL/usr/lib/
+      ln -s ${CRAFT_ARCH_TRIPLET} lib-arch


### PR DESCRIPTION
This PR updates a few things within the `snapcraft.yaml` to conform to current standards/best practices and resolve some run-time bugs.

`snapcraftctl` and `SNAPCRAFT_*` variables are deprecated for core22 base snaps, instead moving to `craftctl` and `CRAFT_*`. 

Additionally, setting the environment globally in a snap is not recommended. Instead, we should set it per-app.

There are also some missing dependencies. I may not have gotten them all, but at least `mcopy` from `mtools` is required to build Ubuntu Core images.