### PR TITLE
Fix the logic of rootfs detection to use for the update_bootloader state

### DIFF
--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -3401,6 +3401,11 @@ func TestUnsupportedBootloader(t *testing.T) {
 		err = stateMachine.loadGadgetYaml()
 		asserter.AssertErrNil(err, true)
 
+		// prepare state in such a way that the rootfs partition was found in
+		// earlier steps
+		stateMachine.rootfsPartNum = 3
+		stateMachine.rootfsVolName = "pc"
+
 		// set the bootloader for the volume to "test"
 		stateMachine.GadgetInfo.Volumes["pc"].Bootloader = "test"
 

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -3314,13 +3314,14 @@ func TestFailedUpdateBootloader(t *testing.T) {
 			Gadget:       &imagedefinition.Gadget{},
 		}
 
-		// first run with an empty gadget to make sure we get an error
-		// need workdir set up for this
+		// set up work dir
 		err := stateMachine.makeTemporaryDirectories()
 		asserter.AssertErrNil(err, true)
 
-		// next use a gadget with grub as the bootloader and mock
-		// filepath.Glob to trigger a failure in updateGrub
+		// first, test that updateBootloader fails when the rootfs partition
+		// has not been found in earlier steps
+		stateMachine.rootfsPartNum = -1
+		stateMachine.rootfsVolName = ""
 		err = stateMachine.updateBootloader()
 		asserter.AssertErrContains(err, "Error: could not determine partition number of the root filesystem")
 
@@ -3337,6 +3338,11 @@ func TestFailedUpdateBootloader(t *testing.T) {
 			osutil.CopyFlagDefault,
 		)
 		asserter.AssertErrNil(err, true)
+
+		// prepare state in such a way that the rootfs partition was found in
+		// earlier steps
+		stateMachine.rootfsPartNum = 3
+		stateMachine.rootfsVolName = "pc"
 
 		// parse gadget.yaml and run updateBootloader with the mocked os.Mkdir
 		err = stateMachine.prepareGadgetTree()

--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -355,7 +355,13 @@ func (stateMachine *StateMachine) makeDisk() error {
 			}
 
 			// set up the partitions on the device
-			partitionTable := createPartitionTable(volumeName, volume, uint64(stateMachine.SectorSize), stateMachine.IsSeeded)
+			partitionTable, rootfsPartitionNumber := createPartitionTable(volumeName, volume, uint64(stateMachine.SectorSize), stateMachine.IsSeeded)
+
+			// Save the rootfs partition number, if found, for later use
+			if rootfsPartitionNumber != -1 {
+				stateMachine.rootfsVolName = volumeName
+				stateMachine.rootfsPartNum = rootfsPartitionNumber
+			}
 
 			// Write the partition table to disk
 			if err := diskImg.Partition(*partitionTable); err != nil {

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -894,6 +894,11 @@ func TestMakeDiskPartitionSchemes(t *testing.T) {
 				t.Errorf("Disk image size %d is not an multiple of the block size: %d",
 					diskImg.Size, int64(stateMachine.SectorSize))
 			}
+
+			// while at it, ensure that the root partition has been found
+			if stateMachine.rootfsPartNum == -1 || stateMachine.rootfsVolName == "" {
+				t.Errorf("Root partition was not found")
+			}
 		})
 	}
 }

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -95,14 +95,16 @@ type temporaryDirectories struct {
 
 // StateMachine will hold the command line data, track the current state, and handle all function calls
 type StateMachine struct {
-	cleanWorkDir bool          // whether or not to clean up the workDir
-	CurrentStep  string        // tracks the current progress of the state machine
-	StepsTaken   int           // counts the number of steps taken
-	YamlFilePath string        // the location for the yaml file
-	IsSeeded     bool          // core 20 images are seeded
-	SectorSize   quantity.Size // parsed (converted) sector size
-	RootfsSize   quantity.Size
-	tempDirs     temporaryDirectories
+	cleanWorkDir  bool          // whether or not to clean up the workDir
+	CurrentStep   string        // tracks the current progress of the state machine
+	StepsTaken    int           // counts the number of steps taken
+	YamlFilePath  string        // the location for the yaml file
+	IsSeeded      bool          // core 20 images are seeded
+	rootfsVolName string        // volume on which the rootfs is located
+	rootfsPartNum int           // rootfs partition number
+	SectorSize    quantity.Size // parsed (converted) sector size
+	RootfsSize    quantity.Size
+	tempDirs      temporaryDirectories
 
 	// The flags that were passed in on the command line
 	commonFlags       *commands.CommonOpts

--- a/internal/statemachine/testdata/gadget-gpt-efi-only.yaml
+++ b/internal/statemachine/testdata/gadget-gpt-efi-only.yaml
@@ -1,0 +1,17 @@
+volumes:
+  pc:
+    schema: gpt
+    bootloader: grub
+    structure:
+      - name: EFI System
+        type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        filesystem: vfat
+        filesystem-label: system-boot
+        size: 50M
+        content:
+          - source: grubx64.efi
+            target: EFI/boot/grubx64.efi
+          - source: shim.efi.signed
+            target: EFI/boot/bootx64.efi
+          - source: grub-cpc.cfg
+            target: EFI/ubuntu/grub.cfg

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap1
+version: 3.0+snap2
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
This PR redesigns a bit how we detect the rootfs for the update_bootloader state in ubuntu-image. We anyway depend on the disk images being created (so make_disk needs to execute first), and make_disk already scans the gadget and creates the partitions. So we use the occasion and save the partition number (and volume) and then use it when running update_bootloader.

Added some tests to accommodate that.