### PR TITLE
Misc papercuts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,13 @@ ubuntu-image (3.0+23.04ubuntu2) UNRELEASED; urgency=medium
   [ mjdonis ]
   * Add missing dependencies for classic images (LP: #2018758)
 
+  [ Loïc Minier ]
+  * Set hostname to ubuntu instead of letting debootstrap copy it from the
+    build environment.
+  * Add trailing newline at end of fstab.
+  * Don't scan build machine for OS entries when generating GRUB config:
+    dpkg-divert os-prober around update-grub.
+
  -- mjdonis <marinajdonis@gmail.com>  Thu, 11 May 2023 12:29:08 +0200
 
 ubuntu-image (2.2+22.10ubuntu1) kinetic; urgency=medium

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -949,7 +949,7 @@ func (stateMachine *StateMachine) customizeFstab() error {
 		)
 		fstabEntries = append(fstabEntries, fstabEntry)
 	}
-	fstabIO.Write([]byte(strings.Join(fstabEntries, "\n")))
+	fstabIO.Write([]byte(strings.Join(fstabEntries, "\n") + "\n"))
 	return nil
 }
 
@@ -1200,7 +1200,7 @@ func (stateMachine *StateMachine) populateClassicRootfsContents() error {
 					re := regexp.MustCompile(`(?m:^LABEL=\S+\s+/\s+(.*)$)`)
 					newContents := re.ReplaceAll(fstabBytes, []byte("LABEL=writable\t/\t$1"))
 					if !strings.Contains(string(newContents), "LABEL=writable") {
-						newContents = []byte("LABEL=writable   /    ext4   defaults    0 0")
+						newContents = []byte("LABEL=writable   /    ext4   defaults    0 0\n")
 					}
 					err := osWriteFile(fstabPath, newContents, 0644)
 					if err != nil {

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -507,6 +507,12 @@ func (stateMachine *StateMachine) createChroot() error {
 			debootstrapCmd.String(), err.Error(), debootstrapOutput.String())
 	}
 
+	// debootstrap copies /etc/hostname from build environment; replace it
+	// with a fresh version
+	hostname := filepath.Join(stateMachine.tempDirs.chroot, "etc", "hostname")
+	hostnameFile, _ := os.OpenFile(hostname, os.O_TRUNC|os.O_WRONLY, 0644)
+	hostnameFile.WriteString("ubuntu\n")
+
 	// add any extra apt sources to /etc/apt/sources.list
 	aptSources := classicStateMachine.ImageDef.GeneratePocketList()
 

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2393,24 +2393,6 @@ func TestBuildGadgetTreeDirectory(t *testing.T) {
 		err := stateMachine.makeTemporaryDirectories()
 		asserter.AssertErrNil(err, true)
 
-		// test the directory method
-		wd, _ := os.Getwd()
-		sourcePath := filepath.Join(wd, "testdata", "gadget_source")
-		sourcePath = "file://" + sourcePath
-		imageDef := imagedefinition.ImageDefinition{
-			Architecture: getHostArch(),
-			Series:       getHostSuite(),
-			Gadget: &imagedefinition.Gadget{
-				GadgetURL:  sourcePath,
-				GadgetType: "directory",
-			},
-		}
-
-		stateMachine.ImageDef = imageDef
-
-		err = stateMachine.buildGadgetTree()
-		asserter.AssertErrNil(err, true)
-
 		// git clone the gadget into a /tmp dir
 		gadgetDir, err := os.MkdirTemp("", "pc-amd64-gadget-")
 		asserter.AssertErrNil(err, true)
@@ -2427,7 +2409,7 @@ func TestBuildGadgetTreeDirectory(t *testing.T) {
 		asserter.AssertErrNil(err, true)
 
 		// now set up the image definition to build from this directory
-		imageDef = imagedefinition.ImageDefinition{
+		imageDef := imagedefinition.ImageDefinition{
 			Architecture: getHostArch(),
 			Series:       getHostSuite(),
 			Gadget: &imagedefinition.Gadget{

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2894,7 +2894,8 @@ func TestCustomizeFstab(t *testing.T) {
 					FsckOrder:    1,
 				},
 			},
-			`LABEL=writable	/	ext4	defaults	1	1`,
+			`LABEL=writable	/	ext4	defaults	1	1
+`,
 		},
 		{
 			"two_entries",
@@ -2917,7 +2918,8 @@ func TestCustomizeFstab(t *testing.T) {
 				},
 			},
 			`LABEL=writable	/	ext4	defaults	0	1
-LABEL=system-boot	/boot/firmware	vfat	defaults	0	1`,
+LABEL=system-boot	/boot/firmware	vfat	defaults	0	1
+`,
 		},
 		{
 			"defaults_assumed",
@@ -2929,7 +2931,8 @@ LABEL=system-boot	/boot/firmware	vfat	defaults	0	1`,
 					FsckOrder:  1,
 				},
 			},
-			`LABEL=writable	/	ext4	defaults	0	1`,
+			`LABEL=writable	/	ext4	defaults	0	1
+`,
 		},
 	}
 

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2363,7 +2363,7 @@ func TestBuildGadgetTreeGit(t *testing.T) {
 			Architecture: getHostArch(),
 			Series:       getHostSuite(),
 			Gadget: &imagedefinition.Gadget{
-				GadgetURL:    "https://github.com/snapcore/pc-amd64-gadget",
+				GadgetURL:    "https://github.com/snapcore/pc-gadget",
 				GadgetType:   "git",
 				GadgetBranch: "classic",
 			},
@@ -2394,7 +2394,7 @@ func TestBuildGadgetTreeDirectory(t *testing.T) {
 		asserter.AssertErrNil(err, true)
 
 		// git clone the gadget into a /tmp dir
-		gadgetDir, err := os.MkdirTemp("", "pc-amd64-gadget-")
+		gadgetDir, err := os.MkdirTemp("", "pc-gadget-")
 		asserter.AssertErrNil(err, true)
 		defer os.RemoveAll(gadgetDir)
 		gitCloneCommand := *exec.Command(
@@ -2402,7 +2402,7 @@ func TestBuildGadgetTreeDirectory(t *testing.T) {
 			"clone",
 			"--branch",
 			"classic",
-			"https://github.com/snapcore/pc-amd64-gadget",
+			"https://github.com/snapcore/pc-gadget",
 			gadgetDir,
 		)
 		err = gitCloneCommand.Run()

--- a/internal/statemachine/testdata/image_definitions/test_amd64.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_amd64.yaml
@@ -6,7 +6,7 @@ series: jammy
 class: preinstalled
 kernel: linux-image-generic
 gadget:
-  url: "https://github.com/snapcore/pc-amd64-gadget.git"
+  url: "https://github.com/snapcore/pc-gadget.git"
   branch: classic
   type: "git"
 rootfs:

--- a/internal/statemachine/testdata/image_definitions/test_bad_ppa_name.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_bad_ppa_name.yaml
@@ -6,7 +6,7 @@ series: jammy
 class: preinstalled
 kernel: linux-image-generic
 gadget:
-  url: "https://github.com/snapcore/pc-amd64-gadget.git"
+  url: "https://github.com/snapcore/pc-gadget.git"
   branch: classic
   type: "git"
 rootfs:

--- a/internal/statemachine/testdata/image_definitions/test_qcow2.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_qcow2.yaml
@@ -6,7 +6,7 @@ series: jammy
 class: preinstalled
 kernel: linux-image-generic
 gadget:
-  url: "https://github.com/snapcore/pc-amd64-gadget.git"
+  url: "https://github.com/snapcore/pc-gadget.git"
   branch: classic
   type: "git"
 rootfs:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap2
+version: 3.0+snap3
 grade: stable
 confinement: classic
 base: core22

--- a/ubuntu-image.rst
+++ b/ubuntu-image.rst
@@ -235,7 +235,7 @@ model assertion
     https://developer.ubuntu.com/en/snappy/guides/prepare-image/
 
 gadget tree (example)
-    https://github.com/snapcore/pc-amd64-gadget
+    https://github.com/snapcore/pc-gadget
 
 cloud-config
     https://help.ubuntu.com/community/CloudInit
@@ -357,6 +357,6 @@ FOOTNOTES
 .. _snap: http://snapcraft.io/
 .. _YAML: https://developer.ubuntu.com/en/snappy/guides/prepare-image/
 .. _`gadget snap`: https://github.com/snapcore/snapd/wiki/Gadget-snap
-.. _`gadget tree`: Example: https://github.com/snapcore/pc-amd64-gadget
+.. _`gadget tree`: Example: https://github.com/snapcore/pc-gadget
 .. _`gadget.yaml`: https://github.com/snapcore/snapd/wiki/Gadget-snap#gadget.yaml
 .. _`image_definition.yaml`: https://github.com/canonical/ubuntu-image/tree/main/internal/imagedefinition#readme


### PR DESCRIPTION
This fixes a few papercuts with current ubuntu-image

- etc/fstab had no final newline at EOF
- GRUB menu included entries from the build system (os-prober was running)
- etc/hostname was copied from the build host
