### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ files, but it will be generalized to build more (eventually all) Ubuntu images.
 
 # Requirements
 
-Ubuntu 18.04 (Bionic Beaver) is the minimum platform requirement, but Ubuntu
-20.04 (Focal Fossa) or newer is recommended. All required third party packages are available in the
-Ubuntu archive.
+Ubuntu 22.04 (Jammy Jellyfish) is the minimum platform requirement. All
+required third party packages are available in the Ubuntu archive.
 
 If you want to run the test suite locally, you should install all the build
 dependencies named in the `debian/control` file.  The easiest way to do that


### PR DESCRIPTION
Bump the version of distro release to Jammy as Jammy supports golang-go of target version a.k.a. >= 2:1.18~

```
$ rmadison  golang-go --architecture=amd64,arm64
 golang-go | 2:1.2.1-2ubuntu1               | trusty/universe           | amd64
 golang-go | 2:1.3.3-1ubuntu4~ubuntu14.04.1 | trusty-backports/universe | amd64, arm64
 golang-go | 2:1.6-1ubuntu4                 | xenial                    | amd64, arm64
 golang-go | 2:1.10~4ubuntu1                | bionic                    | amd64, arm64
 golang-go | 2:1.13~1ubuntu2                | focal                     | amd64, arm64
 golang-go | 2:1.18~0ubuntu2                | jammy                     | amd64, arm64
 golang-go | 2:1.19~1                       | kinetic                   | amd64, arm64
 golang-go | 2:1.20~0ubuntu1                | lunar                     | amd64, arm64
 golang-go | 2:1.20~1                       | mantic                    | amd64, arm64
```