### PR TITLE
Fix handling of resolv.conf in the chroot

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-image (3.0+23.04ubuntu2) UNRELEASED; urgency=medium
+ubuntu-image (3.0+23.04ubuntu1) UNRELEASED; urgency=medium
 
   [ William 'jawn-smith' Wilson ]
   * Redesign classic image builds to use image definition file.
@@ -16,7 +16,11 @@ ubuntu-image (3.0+23.04ubuntu2) UNRELEASED; urgency=medium
   [ Alfonso Sanchez-Beato ]
   * Run patchelf so we get dynamic linker and libs from the core22 base.
 
- -- mjdonis <marinajdonis@gmail.com>  Thu, 11 May 2023 12:29:08 +0200
+  [ Łukasz 'sil2100' Zemczak ]
+  * Fix handling of resolv.conf in chroot, making sure we don't leak the build
+    environment by accident.
+
+ -- Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>  Wed, 12 Jul 2023 12:55:52 +0200
 
 ubuntu-image (2.2+22.10ubuntu1) kinetic; urgency=medium
 

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -1,0 +1,119 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/snapcore/snapd/osutil"
+)
+
+// define some mocked versions of go package functions
+func mockRemove(string) error {
+	return fmt.Errorf("Test Error")
+}
+func mockRename(string, string) error {
+	return fmt.Errorf("Test Error")
+}
+
+// TestRestoreResolvConf tests if resolv.conf is restored correctly
+func TestRestoreResolvConf(t *testing.T) {
+	t.Run("test_restore_resolv_conf", func(t *testing.T) {
+		asserter := Asserter{T: t}
+		// Prepare temporary directory
+		workDir := filepath.Join("/tmp", "ubuntu-image-"+uuid.NewString())
+		err := os.Mkdir(workDir, 0755)
+		asserter.AssertErrNil(err, true)
+		defer os.RemoveAll(workDir)
+
+		// Create test objects for a regular backup
+		err = os.MkdirAll(filepath.Join(workDir, "etc"), 0755)
+		asserter.AssertErrNil(err, true)
+		mainConfPath := filepath.Join(workDir, "etc", "resolv.conf")
+		mainConf, err := os.Create(mainConfPath)
+		asserter.AssertErrNil(err, true)
+		testData := []byte("Main")
+		_, err = mainConf.Write(testData)
+		asserter.AssertErrNil(err, true)
+		mainConf.Close()
+		backupConfPath := filepath.Join(workDir, "etc", "resolv.conf.tmp")
+		backupConf, err := os.Create(backupConfPath)
+		asserter.AssertErrNil(err, true)
+		testData = []byte("Backup")
+		_, err = backupConf.Write(testData)
+		asserter.AssertErrNil(err, true)
+		backupConf.Close()
+
+		err = RestoreResolvConf(workDir)
+		asserter.AssertErrNil(err, true)
+		if osutil.FileExists(backupConfPath) {
+			t.Errorf("Backup resolv.conf.tmp has not been removed")
+		}
+		checkData, err := os.ReadFile(mainConfPath)
+		asserter.AssertErrNil(err, true)
+		if string(checkData) != "Backup" {
+			t.Errorf("Main resolv.conf has not been restored")
+		}
+
+		// Now check if the symlink case also works
+		_, err = os.Create(backupConfPath)
+		asserter.AssertErrNil(err, true)
+		err = os.Remove(mainConfPath)
+		asserter.AssertErrNil(err, true)
+		err = os.Symlink("resolv.conf.tmp", mainConfPath)
+		asserter.AssertErrNil(err, true)
+
+		err = RestoreResolvConf(workDir)
+		asserter.AssertErrNil(err, true)
+		if osutil.FileExists(backupConfPath) {
+			t.Errorf("Backup resolv.conf.tmp has not been removed when dealing with as symlink")
+		}
+		if !osutil.IsSymlink(mainConfPath) {
+			t.Errorf("Main resolv.conf should have remained a symlink, but it is not")
+		}
+	})
+}
+
+// TestFailedRestoreResolvConf tests all resolv.conf error cases
+func TestFailedRestoreResolvConf(t *testing.T) {
+	t.Run("test_failed_restore_resolv_conf", func(t *testing.T) {
+		asserter := Asserter{T: t}
+		// Prepare temporary directory
+		workDir := filepath.Join("/tmp", "ubuntu-image-"+uuid.NewString())
+		err := os.Mkdir(workDir, 0755)
+		asserter.AssertErrNil(err, true)
+		defer os.RemoveAll(workDir)
+
+		// Create test environment
+		err = os.MkdirAll(filepath.Join(workDir, "etc"), 0755)
+		asserter.AssertErrNil(err, true)
+		mainConfPath := filepath.Join(workDir, "etc", "resolv.conf")
+		_, err = os.Create(mainConfPath)
+		asserter.AssertErrNil(err, true)
+		backupConfPath := filepath.Join(workDir, "etc", "resolv.conf.tmp")
+		_, err = os.Create(backupConfPath)
+		asserter.AssertErrNil(err, true)
+
+		// Mock the os.Rename failure
+		osRename = mockRename
+		defer func() {
+			osRename = os.Rename
+		}()
+		err = RestoreResolvConf(workDir)
+		asserter.AssertErrContains(err, "Error moving file")
+
+		// Mock the os.Remove failure
+		err = os.Remove(mainConfPath)
+		asserter.AssertErrNil(err, true)
+		err = os.Symlink("resolv.conf.tmp", mainConfPath)
+		asserter.AssertErrNil(err, true)
+		osRemove = mockRemove
+		defer func() {
+			osRemove = os.Remove
+		}()
+		err = RestoreResolvConf(workDir)
+		asserter.AssertErrContains(err, "Error removing file")
+	})
+}

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -513,6 +513,14 @@ func (stateMachine *StateMachine) createChroot() error {
 	hostname := filepath.Join(stateMachine.tempDirs.chroot, "etc", "hostname")
 	hostnameFile, _ := os.OpenFile(hostname, os.O_TRUNC|os.O_WRONLY, 0644)
 	hostnameFile.WriteString("ubuntu\n")
+	hostnameFile.Close()
+
+	// debootstrap also copies /etc/resolv.conf from build environment; truncate it
+	// as to not leak the host files into the built image
+	resolvConf := filepath.Join(stateMachine.tempDirs.chroot, "etc", "resolv.conf")
+	if err := osTruncate(resolvConf, 0); err != nil {
+		return fmt.Errorf("Error truncating resolv.conf: %s", err.Error())
+	}
 
 	// add any extra apt sources to /etc/apt/sources.list
 	aptSources := classicStateMachine.ImageDef.GeneratePocketList()

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -242,6 +242,8 @@ func TestExecHelperProcess(t *testing.T) {
 			os.Exit(1)
 		}
 		break
+	case "TestFailedCreateChrootSkip":
+		fallthrough
 	case "TestFailedRunLiveBuild":
 		// Do nothing so we don't have to wait for actual lb commands
 		break

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap4
+version: 3.0+snap5
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
We have some logic in place that backs-up the resolv.conf in the chroot, puts the host one in place for package installation and then restores the original resolv.conf so that we don't leak the host config into the images. Sadly, it seems that debootstrap basically copies the resolv.conf from the host system into the chroot it generates. Looking into what live-build was doing, it seems that live-build was always truncating the resolv.conf that we were getting from debootstrap, so let's do the same.
While checking what live-build was doing, I also noticed a nifty conditional that checks if during package installation resolv.conf wasn't substituted with a symlink (example has been given of systemd-resolved or resolvconf), and making sure we leave the new resolv.conf symlink in place. So I added it here as well.

All changes come with testing. Had to add a new test suite for the helper functions.