### PR TITLE
Fix `snapcraft.yaml` to properly use stage-packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,9 +13,11 @@ issues: https://bugs.launchpad.net/ubuntu-image/+filebug
 # Force the snap to use fakeroot staged within the snap
 environment:
   FAKEROOT_FLAGS: "--lib $SNAP/usr/lib/lib-arch/libfakeroot/libfakeroot-tcp.so --faked $SNAP/usr/bin/faked-tcp"
-  PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/sbin:$PATH
+  PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/usr/sbin:$SNAP/sbin:$PATH
   GCONV_PATH: /snap/core20/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gconv
   PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+  DEBOOTSTRAP_DIR: $SNAP/usr/share/debootstrap
+
 
 apps:
   ubuntu-image:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -15,6 +15,7 @@ environment:
   FAKEROOT_FLAGS: "--lib $SNAP/usr/lib/lib-arch/libfakeroot/libfakeroot-tcp.so --faked $SNAP/usr/bin/faked-tcp"
   PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/sbin:$PATH
   GCONV_PATH: /snap/core20/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gconv
+  PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
 
 apps:
   ubuntu-image:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,7 +17,7 @@ environment:
   GCONV_PATH: /snap/core20/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gconv
   PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
   DEBOOTSTRAP_DIR: $SNAP/usr/share/debootstrap
-
+  PERL5LIB: $SNAP/usr/share/perl5:$SNAP/usr/share/perl:$PERL5LIB
 
 apps:
   ubuntu-image:
@@ -45,6 +45,8 @@ parts:
       - make
       - kpartx
       - qemu-utils
+      - devscripts
+      - grub-common
     build-attributes: [ enable-patchelf ]
     override-build: |
       ins_bin=$SNAPCRAFT_PART_INSTALL/bin/


### PR DESCRIPTION
Expanding the `PYTHONPATH` is required to pickup the germinate `stage-package`

Without specifying `PTYHONPATH` you may hit such an error:

```
[8] germinate
Traceback (most recent call last):
  File "/snap/ubuntu-image/512/usr/bin/germinate", line 25, in <module>
    from germinate.scripts.germinate_main import main
ModuleNotFoundError: No module named 'germinate'
```

Additionally, `debootstrap` is a `stage-package` but will not be used -- if `debootstrap` is not installed on the host, you'll run into both a "missing from `$PATH`" error and, after you correct the `$PATH` variable used in the `snapcraft.yaml`, you end up with `debootstrap` being unable to find some relevant files in `/usr/share` -- this can be resolved by setting an environment variable `DEBOOTSTRAP_DIR`.

The last commit in this PR adds two new `stage-packages`: `devscripts` and `grub-common`. It's possible that a user will not have these packages installed, and they are requirements for building some variations of our `pc-gadget` snap (https://github.com/snapcore/pc-gadget/tree/classic). I leave it up to whomever reviews this to determine if these are valid inclusions for `ubuntu-image`. 