### PR TITLE
Don't require the cloud-config header for meta-data and network-config

### DIFF
--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -891,7 +891,7 @@ func (stateMachine *StateMachine) germinate() error {
 }
 
 // customizeCloudInitFile customizes a cloud-init data file with the given content
-func customizeCloudInitFile(customData string, seedPath string, fileName string) error {
+func customizeCloudInitFile(customData string, seedPath string, fileName string, requireHeader bool) error {
 	if customData == "" {
 		return nil
 	}
@@ -901,7 +901,7 @@ func customizeCloudInitFile(customData string, seedPath string, fileName string)
 	}
 	defer f.Close()
 
-	if !strings.HasPrefix(customData, "#cloud-config\n") {
+	if requireHeader && !strings.HasPrefix(customData, "#cloud-config\n") {
 		return fmt.Errorf("provided cloud-init customization for %s is missing proper header", fileName)
 	}
 
@@ -925,17 +925,17 @@ func (stateMachine *StateMachine) customizeCloudInit() error {
 		return err
 	}
 
-	err = customizeCloudInitFile(cloudInitCustomization.MetaData, seedPath, "meta-data")
+	err = customizeCloudInitFile(cloudInitCustomization.MetaData, seedPath, "meta-data", false)
 	if err != nil {
 		return err
 	}
 
-	err = customizeCloudInitFile(cloudInitCustomization.UserData, seedPath, "user-data")
+	err = customizeCloudInitFile(cloudInitCustomization.UserData, seedPath, "user-data", true)
 	if err != nil {
 		return err
 	}
 
-	err = customizeCloudInitFile(cloudInitCustomization.NetworkConfig, seedPath, "network-config")
+	err = customizeCloudInitFile(cloudInitCustomization.NetworkConfig, seedPath, "network-config", false)
 	if err != nil {
 		return err
 	}

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -1200,10 +1200,8 @@ func TestStatemachine_customizeCloudInit_failed(t *testing.T) {
 
 	stateMachine.ImageDef.Customization = &imagedefinition.Customization{
 		CloudInit: &imagedefinition.CloudInit{
-			MetaData: `#cloud-config
-foo: bar`,
-			NetworkConfig: `#cloud-config
-foobar: foobar`,
+			MetaData:      `foo: bar`,
+			NetworkConfig: `foobar: foobar`,
 			UserData: `#cloud-config
 
 chpasswd:
@@ -1316,21 +1314,9 @@ chpasswd:
 		cloudInitCustomization imagedefinition.CloudInit
 	}{
 		{
-			name: "invalid metadata",
-			cloudInitCustomization: imagedefinition.CloudInit{
-				MetaData: "foo: bar",
-			},
-		},
-		{
 			name: "invalid userdata",
 			cloudInitCustomization: imagedefinition.CloudInit{
 				UserData: "foo: bar",
-			},
-		},
-		{
-			name: "invalid network config",
-			cloudInitCustomization: imagedefinition.CloudInit{
-				NetworkConfig: "foo: bar",
 			},
 		},
 	}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.0+snap10
+version: 3.0+snap11
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
I got reports that people now have issues building image as we became a bit too strict. Tried finding in cloud-init documentation if the `#cloud-config` header is needed for other than user-data, but didn't see anything. And truth is that it seems to work as-is when they don't.

I think it makes sense to, for now, be less strict and merge this to at least not break existing users.