### PR TITLE
Make snap more self-contained

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,7 +41,6 @@ parts:
       - germinate
       - mtools
       - make
-      - kpartx
       - qemu-user-static
       - qemu-utils
       - u-boot-tools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,11 +28,6 @@ parts:
     plugin: nil
     source: .
     source-type: git
-    build-packages:
-      - fdisk
-      - gdisk
-      - mtools
-      - python3-docutils
     build-snaps:
       - go
     stage-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -52,6 +52,13 @@ parts:
       - u-boot-tools
       - devscripts
       - grub-common
+      - libpython3-stdlib
+      - libpython3.10-stdlib
+      - libpython3.10-minimal
+      - python3
+      - python3-apt
+      - python3-minimal
+      - python3.10-minimal
     build-attributes: [ enable-patchelf ]
     override-build: |
       ins_bin=$SNAPCRAFT_PART_INSTALL/bin/


### PR DESCRIPTION
First commit is self-explanatory -- I don't think fdisk, gdisk, or mtools are ever used during the build and only matter for running `ubuntu-image`.

Second commit resolves a bug that exists in a particular release of `mtools` in Jammy. I only saw this bug in the case where my Classic gadget snap was installing a firmware file to a bare partition (writing directly to sectors on the image). I don't really know why this doesn't show up when creating Core images.

Third commit adds a required package (`python3-apt`) which matters when creating a Classic image which adds a `custom-ppa` to the image (for instance, when building a Classic image which uses a kernel provided by some private Launchpad project).
`python3-apt` doesn't play nicely with particular Python interpreters. For instance, it isn't sufficient to stage `python3-apt` on 23.04. Instead, you must stage all of the python3 available in 22.04. Normally you would just add `python3` as a `stage-package`, but because of how Snapcraft handles certain dependencies which may be available in the base snap, we have to explicitly install all the packages python3 would normally get us. (Snapcraft itself has this same problem).