### PR TITLE
Run the spread tests using google backend in self-hosted runners

### DIFF
--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -4,19 +4,25 @@ on: [pull_request]
 
 jobs:
   spread:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        system:
-          - ubuntu-18.04
-          - ubuntu-20.04
+    runs-on: self-hosted
     steps:
+      - name: Cleanup job workspace
+        id: cleanup-job-workspace
+        run: |
+            rm -rf "${{ github.workspace }}"
+            mkdir "${{ github.workspace }}"
+
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 2
-      - name: Download spread
-        run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | tar -xz
-      - name: Init lxd
-        run: sudo lxd init --auto
+          fetch-depth: 0
+
       - name: Run spread tests
-        run: sudo ./spread lxd:${{ matrix.system }}
+        run: spread google:tests/
+
+      - name: Discard spread workers
+        if: always()
+        run: |
+          shopt -s nullglob;
+          for r in .spread-reuse.*.yaml; do
+            spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
+          done

--- a/spread.yaml
+++ b/spread.yaml
@@ -7,6 +7,15 @@ backends:
       - ubuntu-20.04
         #- ubuntu-22.04
 
+  google:
+    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+    location: snapd-spread/us-east1-b
+    halt-timeout: 2h
+    systems:
+      - ubuntu-18.04-64:
+      - ubuntu-20.04-64:
+
+
 path: /home/ubuntu-image
 
 prepare: |


### PR DESCRIPTION
This change allowes to run the spread tests in slef-hosted runners in the canonical env and also using the google backend instead of lxd.

The spread job includes the initial cleanup, the tests execution and the last step used to make sure all the vms are deleted in google cloud.