### PR TITLE
Re-Add component and pocket customization in resulting image

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -20,6 +20,7 @@ ubuntu-image (3.1) UNRELEASED; urgency=medium
   * Add a make-dirs manual customization option to create directories in the rootfs
   * use eatmydata to speed up debootstrap
   * Make sure we unmount/detach everything if the update_bootloader state is failing
+  * Enable distinguish build and target components/pockets
 
   [ Alfonso Sanchez-Beato ]
   * Update to latest snapd, adapting to changes in layouts code.

--- a/internal/imagedefinition/README.rst
+++ b/internal/imagedefinition/README.rst
@@ -67,7 +67,7 @@ The following specification defines what is supported in the YAML:
        # archive-tasks, or tarball.
        rootfs:
          # Components are a list of apt sources, such as main,
-         # universe, and restricted. Defaults to "release".
+         # universe, and restricted. Defaults to "main,restricted".
          components: (optional)
            - <string>
            - <string>
@@ -128,7 +128,22 @@ The following specification defines what is supported in the YAML:
        # ubuntu-image supports building automatically with some
        # customizations to the image. Note that if customization
        # is specified, at least one of the subkeys should be used
+       # This is only supported for classic image building 
        customization: (optional)
+         # Components are a list of apt sources, such as main,
+         # universe, and restricted. Defaults to "main, restricted, universe".
+         # These are used in the resulting img, not to build it.
+         components: (optional)
+           - <string>
+           - <string>
+         # Ubuntu offers several pockets, which often imply the
+         # inclusion of other pockets. The release pocket only
+         # includes itself. The security pocket includes itself
+         # and the release pocket. Updates includes updates,
+         # security, and release. Proposed includes all pockets.
+         # Defaults to "release".
+         # This value is in the resulting img, not to build it.
+         pocket: release | security | updates | proposed (optional)
          # Used only for installer images
          installer: (optional)
            preseeds: (optional)

--- a/internal/imagedefinition/image_definition.go
+++ b/internal/imagedefinition/image_definition.go
@@ -39,7 +39,7 @@ type Gadget struct {
 
 // Rootfs defines the rootfs section of the image definition file
 type Rootfs struct {
-	Components   []string `yaml:"components"    json:"Components,omitempty"`
+	Components   []string `yaml:"components"    json:"Components,omitempty"   default:"main,restricted"`
 	Archive      string   `yaml:"archive"       json:"Archive"                default:"ubuntu"`
 	Flavor       string   `yaml:"flavor"        json:"Flavor"                 default:"ubuntu"`
 	Mirror       string   `yaml:"mirror"        json:"Mirror"                 default:"http://archive.ubuntu.com/ubuntu/"`
@@ -70,6 +70,8 @@ type Tarball struct {
 // The extra_step_prebuilt_rootfs struct tag denotes that an extra state will
 // need to be added for image builds with prebuilt root filesystems.
 type Customization struct {
+	Components    []string   `yaml:"components"     json:"Components,omitempty"   default:"main,restricted,universe"`
+	Pocket        string     `yaml:"pocket"         json:"Pocket"                 jsonschema:"enum=release,enum=Release,enum=updates,enum=Updates,enum=security,enum=Security,enum=proposed,enum=Proposed" default:"release"`
 	Installer     *Installer `yaml:"installer"      json:"Installer,omitempty"`
 	CloudInit     *CloudInit `yaml:"cloud-init"     json:"CloudInit,omitempty"`
 	ExtraPPAs     []*PPA     `yaml:"extra-ppas"     json:"ExtraPPAs,omitempty"     extra_step_prebuilt_rootfs:"add_extra_ppas"`
@@ -312,50 +314,50 @@ func (imageDef ImageDefinition) securityMirror() string {
 	return imageDef.Rootfs.Mirror
 }
 
-// GeneratePocketList returns a slice of strings that need to be added to
-// /etc/apt/sources.list in the chroot based on the value of "pocket"
-// in the rootfs section of the image definition
-func (imageDef ImageDefinition) GeneratePocketList() []string {
-	pocketMap := map[string][]string{
-		"release": {},
-		"security": {
-			fmt.Sprintf("deb %s %s-security %s\n",
-				imageDef.securityMirror(),
-				imageDef.Series,
-				strings.Join(imageDef.Rootfs.Components, " "),
-			),
-		},
-		"updates": {
-			fmt.Sprintf("deb %s %s-updates %s\n",
-				imageDef.Rootfs.Mirror,
-				imageDef.Series,
-				strings.Join(imageDef.Rootfs.Components, " "),
-			),
-			fmt.Sprintf("deb %s %s-security %s\n",
-				imageDef.securityMirror(),
-				imageDef.Series,
-				strings.Join(imageDef.Rootfs.Components, " "),
-			),
-		},
-		"proposed": {
-			fmt.Sprintf("deb %s %s-updates %s\n",
-				imageDef.Rootfs.Mirror,
-				imageDef.Series,
-				strings.Join(imageDef.Rootfs.Components, " "),
-			),
-			fmt.Sprintf("deb %s %s-security %s\n",
-				imageDef.securityMirror(),
-				imageDef.Series,
-				strings.Join(imageDef.Rootfs.Components, " "),
-			),
-			fmt.Sprintf("deb %s %s-proposed %s\n",
-				imageDef.Rootfs.Mirror,
-				imageDef.Series,
-				strings.Join(imageDef.Rootfs.Components, " "),
-			),
-		},
+func generatePocketList(series string, components []string, mirror string, securityMirror string, pocket string) []string {
+	baseList := fmt.Sprintf("deb %%s %s%%s %s\n", series, strings.Join(components, " "))
+
+	releaseList := fmt.Sprintf(baseList, mirror, "")
+	securityList := fmt.Sprintf(baseList, securityMirror, "-security")
+	updatesList := fmt.Sprintf(baseList, mirror, "-updates")
+	proposedList := fmt.Sprintf(baseList, mirror, "-proposed")
+
+	pocketList := make([]string, 0)
+
+	switch pocket {
+	case "release":
+		pocketList = append(pocketList, releaseList)
+	case "security":
+		pocketList = append(pocketList, releaseList, securityList)
+	case "updates":
+		pocketList = append(pocketList, releaseList, securityList, updatesList)
+	case "proposed":
+		pocketList = append(pocketList, releaseList, securityList, updatesList, proposedList)
 	}
 
-	// Schema validation has already confirmed the Pocket is a valid value
-	return pocketMap[strings.ToLower(imageDef.Rootfs.Pocket)]
+	return pocketList
+}
+
+// BuildPocketList returns a slice of strings that need to be added to
+// /etc/apt/sources.list in the chroot to build the image, based on the value of "pocket"
+// in the rootfs section of the image definition
+func (imageDef ImageDefinition) BuildPocketList() []string {
+	return generatePocketList(
+		imageDef.Series,
+		imageDef.Rootfs.Components,
+		imageDef.Rootfs.Mirror,
+		imageDef.securityMirror(),
+		strings.ToLower(imageDef.Rootfs.Pocket))
+}
+
+// TargetPocketList returns a slice of strings that need to be added to
+// /etc/apt/sources.list in the chroot for the target image, based on the value of "pocket"
+// in the customization section of the image definition
+func (imageDef ImageDefinition) TargetPocketList() []string {
+	return generatePocketList(
+		imageDef.Series,
+		imageDef.Customization.Components,
+		imageDef.Rootfs.Mirror,
+		imageDef.securityMirror(),
+		strings.ToLower(imageDef.Customization.Pocket))
 }

--- a/internal/imagedefinition/image_definition_test.go
+++ b/internal/imagedefinition/image_definition_test.go
@@ -4,70 +4,78 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/canonical/ubuntu-image/internal/helper"
 )
 
 func TestGeneratePocketList(t *testing.T) {
+	type args struct {
+		series         string
+		components     []string
+		mirror         string
+		securityMirror string
+		pocket         string
+	}
+
 	testCases := []struct {
 		name            string
 		imageDef        ImageDefinition
+		args            args
 		expectedPockets []string
 	}{
 		{
-			"release",
-			ImageDefinition{
-				Series: "jammy",
-				Rootfs: &Rootfs{
-					Pocket:     "release",
-					Components: []string{"main", "universe"},
-					Mirror:     "http://archive.ubuntu.com/ubuntu/",
-				},
+			name: "release",
+			args: args{
+				series:         "jammy",
+				components:     []string{"main", "universe"},
+				mirror:         "http://archive.ubuntu.com/ubuntu/",
+				securityMirror: "http://security.ubuntu.com/ubuntu/",
+				pocket:         "release",
 			},
-			[]string{},
+			expectedPockets: []string{"deb http://archive.ubuntu.com/ubuntu/ jammy main universe\n"},
 		},
 		{
-			"security",
-			ImageDefinition{
-				Architecture: "amd64",
-				Series:       "jammy",
-				Rootfs: &Rootfs{
-					Pocket:     "security",
-					Components: []string{"main"},
-					Mirror:     "http://archive.ubuntu.com/ubuntu/",
-				},
+			name: "security",
+			args: args{
+				series:         "jammy",
+				components:     []string{"main"},
+				mirror:         "http://archive.ubuntu.com/ubuntu/",
+				pocket:         "security",
+				securityMirror: "http://security.ubuntu.com/ubuntu/",
 			},
-			[]string{"deb http://security.ubuntu.com/ubuntu/ jammy-security main\n"},
+			expectedPockets: []string{
+				"deb http://archive.ubuntu.com/ubuntu/ jammy main\n",
+				"deb http://security.ubuntu.com/ubuntu/ jammy-security main\n",
+			},
 		},
 		{
-			"updates",
-			ImageDefinition{
-				Architecture: "arm64",
-				Series:       "jammy",
-				Rootfs: &Rootfs{
-					Pocket:     "updates",
-					Components: []string{"main", "universe", "multiverse"},
-					Mirror:     "http://ports.ubuntu.com/",
-				},
+			name: "updates",
+			args: args{
+				series:         "jammy",
+				components:     []string{"main", "universe", "multiverse"},
+				mirror:         "http://ports.ubuntu.com/",
+				securityMirror: "http://ports.ubuntu.com/",
+				pocket:         "updates",
 			},
-			[]string{
+			expectedPockets: []string{
+				"deb http://ports.ubuntu.com/ jammy main universe multiverse\n",
 				"deb http://ports.ubuntu.com/ jammy-security main universe multiverse\n",
 				"deb http://ports.ubuntu.com/ jammy-updates main universe multiverse\n",
 			},
 		},
 		{
-			"proposed",
-			ImageDefinition{
-				Architecture: "amd64",
-				Series:       "jammy",
-				Rootfs: &Rootfs{
-					Pocket:     "proposed",
-					Components: []string{"main", "universe", "multiverse", "restricted"},
-					Mirror:     "http://archive.ubuntu.com/ubuntu/",
-				},
+			name: "proposed",
+			args: args{
+				series:         "jammy",
+				components:     []string{"main", "universe", "multiverse", "restricted"},
+				mirror:         "http://archive.ubuntu.com/ubuntu/",
+				securityMirror: "http://security.ubuntu.com/ubuntu/",
+				pocket:         "proposed",
 			},
-			[]string{
+			expectedPockets: []string{
+				"deb http://archive.ubuntu.com/ubuntu/ jammy main universe multiverse restricted\n",
 				"deb http://security.ubuntu.com/ubuntu/ jammy-security main universe multiverse restricted\n",
 				"deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe multiverse restricted\n",
 				"deb http://archive.ubuntu.com/ubuntu/ jammy-proposed main universe multiverse restricted\n",
@@ -76,7 +84,13 @@ func TestGeneratePocketList(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run("test_generate_pocket_list_"+tc.name, func(t *testing.T) {
-			pocketList := tc.imageDef.GeneratePocketList()
+			pocketList := generatePocketList(
+				tc.args.series,
+				tc.args.components,
+				tc.args.mirror,
+				tc.args.securityMirror,
+				tc.args.pocket,
+			)
 			for _, expectedPocket := range tc.expectedPockets {
 				found := false
 				for _, pocket := range pocketList {
@@ -154,7 +168,7 @@ func TestCustomErrors(t *testing.T) {
 func TestImageDefinition_SetDefaults(t *testing.T) {
 	t.Run("test_image_definition_valid_defaults", func(t *testing.T) {
 		asserter := helper.Asserter{T: t}
-		err := helper.SetDefaults(&ImageDefinition{
+		imageDef := &ImageDefinition{
 			Gadget: &Gadget{},
 			Rootfs: &Rootfs{
 				Seed:    &Seed{},
@@ -178,7 +192,118 @@ func TestImageDefinition_SetDefaults(t *testing.T) {
 				Changelog: &Changelog{},
 				RootfsTar: &RootfsTar{},
 			},
-		})
+		}
+
+		want := &ImageDefinition{
+			Gadget: &Gadget{},
+			Rootfs: &Rootfs{
+				Seed: &Seed{
+					Vcs: helper.BoolPtr(true),
+				},
+				Tarball:    &Tarball{},
+				Components: []string{"main", "restricted"},
+				Archive:    "ubuntu",
+				Flavor:     "ubuntu",
+				Mirror:     "http://archive.ubuntu.com/ubuntu/",
+				Pocket:     "release",
+			},
+			Customization: &Customization{
+				Components: []string{"main", "restricted", "universe"},
+				Pocket:     "release",
+				Installer:  &Installer{},
+				CloudInit:  &CloudInit{},
+				ExtraPPAs: []*PPA{{
+					KeepEnabled: helper.BoolPtr(true),
+				}},
+				ExtraPackages: []*Package{{}},
+				ExtraSnaps: []*Snap{{
+					Store:   "canonical",
+					Channel: "stable",
+				}},
+				Fstab: []*Fstab{{
+					MountOptions: "defaults",
+				}},
+				Manual: &Manual{},
+			},
+			Artifacts: &Artifact{
+				Img:       &[]Img{{}},
+				Iso:       &[]Iso{{}},
+				Qcow2:     &[]Qcow2{{}},
+				Manifest:  &Manifest{},
+				Filelist:  &Filelist{},
+				Changelog: &Changelog{},
+				RootfsTar: &RootfsTar{
+					Compression: "uncompressed",
+				},
+			},
+		}
+
+		err := helper.SetDefaults(imageDef)
 		asserter.AssertErrNil(err, true)
+
+		asserter.AssertEqual(want, imageDef, cmp.AllowUnexported(ImageDefinition{}))
 	})
+}
+
+func TestImageDefinition_securityMirror(t *testing.T) {
+	type fields struct {
+		Architecture string
+		Rootfs       *Rootfs
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "amd64",
+			fields: fields{
+				Architecture: "amd64",
+				Rootfs: &Rootfs{
+					Mirror: "http://archive.ubuntu.com/ubuntu/",
+				},
+			},
+			want: "http://security.ubuntu.com/ubuntu/",
+		},
+		{
+			name: "i386",
+			fields: fields{
+				Architecture: "i386",
+				Rootfs: &Rootfs{
+					Mirror: "http://archive.ubuntu.com/ubuntu/",
+				},
+			},
+			want: "http://security.ubuntu.com/ubuntu/",
+		},
+		{
+			name: "arm64",
+			fields: fields{
+				Architecture: "arm64",
+				Rootfs: &Rootfs{
+					Mirror: "http://archive.ubuntu.com/ubuntu/",
+				},
+			},
+			want: "http://archive.ubuntu.com/ubuntu/",
+		},
+		{
+			name: "no arch",
+			fields: fields{
+				Rootfs: &Rootfs{
+					Mirror: "http://archive.ubuntu.com/ubuntu/",
+				},
+			},
+			want: "http://archive.ubuntu.com/ubuntu/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imageDef := ImageDefinition{
+				Architecture: tt.fields.Architecture,
+				Rootfs:       tt.fields.Rootfs,
+			}
+			if got := imageDef.securityMirror(); got != tt.want {
+				t.Errorf("ImageDefinition.securityMirror() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -312,6 +312,9 @@ func (stateMachine *StateMachine) calculateStates() error {
 	rootfsCreationStates = append(rootfsCreationStates,
 		stateFunc{"clean_rootfs", (*StateMachine).cleanRootfs})
 
+	rootfsCreationStates = append(rootfsCreationStates,
+		stateFunc{"customize_sources_list", (*StateMachine).customizeSourcesList})
+
 	// Determine any customization that needs to run before the image is created
 	//TODO: installer image customization... eventually.
 	if classicStateMachine.ImageDef.Customization != nil {
@@ -517,6 +520,21 @@ func (stateMachine *StateMachine) prepareGadgetTree() error {
 	return nil
 }
 
+// fixHostname set fresh hostname since debootstrap copies /etc/hostname from build environment
+func (stateMachine *StateMachine) fixHostname() error {
+	hostname := filepath.Join(stateMachine.tempDirs.chroot, "etc", "hostname")
+	hostnameFile, err := osOpenFile(hostname, os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("unable to open hostname file: %w", err)
+	}
+	defer hostnameFile.Close()
+	_, err = hostnameFile.WriteString("ubuntu\n")
+	if err != nil {
+		return fmt.Errorf("unable to write hostname: %w", err)
+	}
+	return nil
+}
+
 // Bootstrap a chroot environment to install packages in. It will eventually
 // become the rootfs of the image
 func (stateMachine *StateMachine) createChroot() error {
@@ -538,18 +556,10 @@ func (stateMachine *StateMachine) createChroot() error {
 			debootstrapCmd.String(), err.Error(), debootstrapOutput.String())
 	}
 
-	// debootstrap copies /etc/hostname from build environment; replace it
-	// with a fresh version
-	hostname := filepath.Join(stateMachine.tempDirs.chroot, "etc", "hostname")
-	hostnameFile, err := osOpenFile(hostname, os.O_TRUNC|os.O_WRONLY, 0644)
+	err := stateMachine.fixHostname()
 	if err != nil {
-		return fmt.Errorf("unable to open hostname file: %w", err)
+		return err
 	}
-	_, err = hostnameFile.WriteString("ubuntu\n")
-	if err != nil {
-		return fmt.Errorf("unable to write hostname: %w", err)
-	}
-	hostnameFile.Close()
 
 	// debootstrap also copies /etc/resolv.conf from build environment; truncate it
 	// as to not leak the host files into the built image
@@ -559,21 +569,7 @@ func (stateMachine *StateMachine) createChroot() error {
 	}
 
 	// add any extra apt sources to /etc/apt/sources.list
-	aptSources := classicStateMachine.ImageDef.GeneratePocketList()
-
-	sourcesList := filepath.Join(stateMachine.tempDirs.chroot, "etc", "apt", "sources.list")
-	sourcesListFile, err := osOpenFile(sourcesList, os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("unable to open sources.list file: %w", err)
-	}
-	for _, aptSource := range aptSources {
-		_, err = sourcesListFile.WriteString(aptSource)
-		if err != nil {
-			return fmt.Errorf("unable to write apt sources: %w", err)
-		}
-	}
-
-	return nil
+	return stateMachine.overwriteSourcesList(classicStateMachine.ImageDef.BuildPocketList())
 }
 
 // add PPAs to the apt sources list
@@ -618,12 +614,12 @@ func (stateMachine *StateMachine) addExtraPPAs() (err error) {
 			err = fmt.Errorf("Error creating %s: %s", ppaFile, err.Error())
 			return err
 		}
+		defer ppaIO.Close()
 		_, err = ppaIO.Write([]byte(ppaFileContents))
 		if err != nil {
 			err = fmt.Errorf("unable to write ppa file %s: %w", ppaFile, err)
 			return err
 		}
-		ppaIO.Close()
 
 		// Import keys either from the specified fingerprint or via the Launchpad API
 		/* TODO: this is the logic for deb822 sources. When other projects
@@ -1319,6 +1315,32 @@ func (stateMachine *StateMachine) populateClassicRootfsContents() error {
 	}
 
 	return classicStateMachine.fixFstab()
+}
+
+// customizeSourcesList customize the /etc/apt/sources.list file for the
+// resulting image. This state must be executed once packages installation
+// is done, and before other manual customization to let users modify it.
+func (stateMachine *StateMachine) customizeSourcesList() error {
+	classicStateMachine := stateMachine.parent.(*ClassicStateMachine)
+	return stateMachine.overwriteSourcesList(classicStateMachine.ImageDef.TargetPocketList())
+}
+
+// overwriteSourcesList replaces /etc/apt/sources.list with the given list of entries
+// This function will truncate the existing file.
+func (stateMachine *StateMachine) overwriteSourcesList(aptSources []string) error {
+	sourcesList := filepath.Join(stateMachine.tempDirs.chroot, "etc", "apt", "sources.list")
+	sourcesListFile, err := osOpenFile(sourcesList, os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("unable to open sources.list file: %w", err)
+	}
+	defer sourcesListFile.Close()
+	for _, aptSource := range aptSources {
+		_, err = sourcesListFile.WriteString(aptSource)
+		if err != nil {
+			return fmt.Errorf("unable to write apt sources: %w", err)
+		}
+	}
+	return nil
 }
 
 // fixFstab makes sure the fstab contains a valid entry for the root mount point

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -920,6 +920,10 @@ func checkCustomizationSteps(searchStruct interface{}, tag string) (extraStates 
 	for i := 0; i < elem.NumField(); i++ {
 		field := elem.Field(i)
 
+		if field.Kind() == reflect.String {
+			continue
+		}
+
 		if !field.IsNil() {
 			tags := elem.Type().Field(i).Tag
 			tagValue, hasTag := tags.Lookup(tag)

--- a/internal/statemachine/testdata/image_definitions/test_amd64.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_amd64.yaml
@@ -29,6 +29,12 @@ customization:
     make-dirs:
       - path: /etc/foo/bar
         permissions: 0755
+  components:
+    - main
+    - universe
+    - restricted
+    - multiverse
+  pocket: proposed
   cloud-init:
     user-data: |
       #cloud-config

--- a/internal/statemachine/tests_helper_test.go
+++ b/internal/statemachine/tests_helper_test.go
@@ -3,6 +3,7 @@ package statemachine
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"os/exec"
 )
 
@@ -11,6 +12,7 @@ type osMockConf struct {
 	ReadDirThreshold               uint
 	RemoveThreshold                uint
 	TruncateThreshold              uint
+	OpenFileThreshold              uint
 }
 
 // osMock holds methods to easily mock functions from os and snapd/osutil packages
@@ -23,6 +25,7 @@ type osMock struct {
 	beforeReadDirFail               uint
 	beforeRemoveFail                uint
 	beforeTruncateFail              uint
+	beforeOpenFileFail              uint
 }
 
 func (o *osMock) CopySpecialFile(path, dest string) error {
@@ -59,6 +62,15 @@ func (o *osMock) Truncate(name string, size int64) error {
 	o.beforeTruncateFail++
 
 	return nil
+}
+
+func (o *osMock) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	if o.beforeOpenFileFail >= o.conf.OpenFileThreshold {
+		return nil, fmt.Errorf("OpenFile fail")
+	}
+	o.beforeOpenFileFail++
+
+	return &os.File{}, nil
 }
 
 func NewOSMock(conf *osMockConf) *osMock {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: 3.1
+version: 3.1+snap1
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
This reverts commit 82c3ac0dcd3d7d1ed1b0fb0120a3eb4aee785d85, which reverted the whole PR https://github.com/canonical/ubuntu-image/pull/160 removed to cut the 3.1 released.