### PR TITLE
FR-6365 - Improve mountpoints handling

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         test-scenario: [short, long]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: install-go

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: changelog-check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       

--- a/.github/workflows/go-quality-checks.yml
+++ b/.github/workflows/go-quality-checks.yml
@@ -6,7 +6,7 @@ jobs:
   check_quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/inclusive-naming.yml
+++ b/.github/workflows/inclusive-naming.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: tj-actions/changed-files@v34.5.1
         id: files

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Run govulncheck
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/snapcraft_yaml.yml
+++ b/.github/workflows/snapcraft_yaml.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: changelog-check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       

--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -16,7 +16,7 @@ jobs:
         uses: snapcore/action-build@v1
 
       - name: Upload snap artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snap
           path: ${{ steps.build-snap.outputs.snap }}
@@ -36,12 +36,12 @@ jobs:
             rm -rf "${{ github.workspace }}"
             mkdir "${{ github.workspace }}"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: Download snap artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snap
           path: tests
@@ -53,7 +53,7 @@ jobs:
         shell: bash
 
       - name: Get previous cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "${{ github.workspace }}/.test-results"
           key: "${{ github.job }}-results-${{ github.run_id }}-${{ steps.get-previous-attempt.outputs.previous_attempt }}"
@@ -142,7 +142,7 @@ jobs:
 
       - name: save spread test results to cache
         if: always()
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: "${{ github.workspace }}/.test-results"
           key: "${{ github.job }}-results-${{ github.run_id }}-${{ github.run_attempt }}"

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -347,40 +347,36 @@ func (stateMachine *StateMachine) installPackages() error {
 	// mount some necessary partitions in the chroot
 	mountPoints := []mountPoint{
 		{
-			relpath:  "/dev",
-			typ:      "devtmpfs",
-			src:      "devtmpfs-build",
-			fromHost: true,
+			relpath: "/dev",
+			typ:     "devtmpfs",
+			src:     "devtmpfs-build",
 		},
 		{
-			relpath:  "/dev/pts",
-			typ:      "devpts",
-			src:      "devpts-build",
-			options:  []string{"nodev", "nosuid"},
-			fromHost: true,
+			relpath: "/dev/pts",
+			typ:     "devpts",
+			src:     "devpts-build",
+			options: []string{"nodev", "nosuid"},
 		},
 		{
-			relpath:  "/proc",
-			typ:      "proc",
-			src:      "proc-build",
-			fromHost: true,
+			relpath: "/proc",
+			typ:     "proc",
+			src:     "proc-build",
 		},
 		{
-			relpath:  "/sys",
-			typ:      "sysfs",
-			src:      "sysfs-build",
-			fromHost: true,
+			relpath: "/sys",
+			typ:     "sysfs",
+			src:     "sysfs-build",
 		},
 		{
-			relpath:  "/run",
-			fromHost: false,
+			relpath: "/run",
+			bind:    true,
 		},
 	}
 
 	for _, mp := range mountPoints {
 		var mountCmds, umountCmds []*exec.Cmd
 		var err error
-		if !mp.fromHost {
+		if mp.bind {
 			mp.src, err = osMkdirTemp(stateMachine.tempDirs.scratch, strings.Trim(mp.relpath, "/"))
 			if err != nil {
 				return fmt.Errorf("Error mounting temporary directory for mountpoint \"%s\": \"%s\"",
@@ -390,7 +386,7 @@ func (stateMachine *StateMachine) installPackages() error {
 			}
 		}
 
-		mountCmds, umountCmds, err = getMountCmd(mp.typ, mp.src, stateMachine.tempDirs.chroot, mp.relpath, mp.fromHost, mp.options...)
+		mountCmds, umountCmds, err = getMountCmd(mp.typ, mp.src, stateMachine.tempDirs.chroot, mp.relpath, mp.bind, mp.options...)
 		if err != nil {
 			return fmt.Errorf("Error preparing mountpoint \"%s\": \"%s\"",
 				mp.relpath,
@@ -886,35 +882,30 @@ func (stateMachine *StateMachine) preseedClassicImage() (err error) {
 	// set up the mount commands
 	mountPoints := []mountPoint{
 		{
-			relpath:  "/dev",
-			typ:      "devtmpfs",
-			src:      "devtmpfs-build",
-			fromHost: true,
+			relpath: "/dev",
+			typ:     "devtmpfs",
+			src:     "devtmpfs-build",
 		},
 		{
-			relpath:  "/dev/pts",
-			typ:      "devpts",
-			src:      "devpts-build",
-			options:  []string{"nodev", "nosuid"},
-			fromHost: true,
+			relpath: "/dev/pts",
+			typ:     "devpts",
+			src:     "devpts-build",
+			options: []string{"nodev", "nosuid"},
 		},
 		{
-			relpath:  "/proc",
-			typ:      "proc",
-			src:      "proc-build",
-			fromHost: true,
+			relpath: "/proc",
+			typ:     "proc",
+			src:     "proc-build",
 		},
 		{
-			relpath:  "/sys/kernel/security",
-			typ:      "securityfs",
-			src:      "none",
-			fromHost: true,
+			relpath: "/sys/kernel/security",
+			typ:     "securityfs",
+			src:     "none",
 		},
 		{
-			relpath:  "/sys/fs/cgroup",
-			typ:      "cgroup2",
-			src:      "none",
-			fromHost: true,
+			relpath: "/sys/fs/cgroup",
+			typ:     "cgroup2",
+			src:     "none",
 		},
 	}
 
@@ -937,7 +928,7 @@ func (stateMachine *StateMachine) preseedClassicImage() (err error) {
 	}()
 
 	for _, mountPoint := range mountPoints {
-		mountCmds, umountCmds, err := getMountCmd(mountPoint.typ, mountPoint.src, stateMachine.tempDirs.chroot, mountPoint.relpath, mountPoint.fromHost, mountPoint.options...)
+		mountCmds, umountCmds, err := getMountCmd(mountPoint.typ, mountPoint.src, stateMachine.tempDirs.chroot, mountPoint.relpath, mountPoint.bind, mountPoint.options...)
 		if err != nil {
 			return fmt.Errorf("Error preparing mountpoint \"%s\": \"%s\"",
 				mountPoint.relpath,

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -385,12 +385,14 @@ func (stateMachine *StateMachine) installPackages() error {
 					mount.dest,
 					err.Error(),
 				)
-
 			}
 		}
 		installPackagesCmds = append(installPackagesCmds, mountCmds...)
 		teardownCmds = append(umountCmds, teardownCmds...)
 	}
+	teardownCmds = append([]*exec.Cmd{
+		execCommand("udevadm", "settle"),
+	}, teardownCmds...)
 
 	aptCmds := generateAptCmds(stateMachine.tempDirs.chroot, classicStateMachine.Packages)
 	installPackagesCmds = append(installPackagesCmds, aptCmds...)

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -3844,6 +3844,7 @@ func TestStateMachine_installPackages_checkcmds_failing(t *testing.T) {
 		regexp.MustCompile("mount --bind .*/scratch/run.* .*/chroot/run"),
 		regexp.MustCompile("chroot /tmp.*/chroot apt update"),
 		regexp.MustCompile("chroot /tmp.*/chroot apt install --assume-yes --quiet --option=Dpkg::options::=--force-unsafe-io --option=Dpkg::Options::=--force-confold"),
+		regexp.MustCompile("udevadm settle"),
 		regexp.MustCompile("umount /tmp.*/chroot/run"),
 		regexp.MustCompile("mount --make-rprivate /tmp.*/chroot/sys"),
 		regexp.MustCompile("umount --recursive /tmp.*/chroot/sys"),

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2862,33 +2862,29 @@ func TestSuccessfulClassicRun(t *testing.T) {
 	// set up the mountpoints
 	mountPoints := []mountPoint{
 		{
-			relpath:  "/dev",
-			typ:      "devtmpfs",
-			src:      "devtmpfs-build",
-			fromHost: true,
+			relpath: "/dev",
+			typ:     "devtmpfs",
+			src:     "devtmpfs-build",
 		},
 		{
-			relpath:  "/dev/pts",
-			typ:      "devpts",
-			src:      "devpts-build",
-			options:  []string{"nodev", "nosuid"},
-			fromHost: true,
+			relpath: "/dev/pts",
+			typ:     "devpts",
+			src:     "devpts-build",
+			options: []string{"nodev", "nosuid"},
 		},
 		{
-			relpath:  "/proc",
-			typ:      "proc",
-			src:      "proc-build",
-			fromHost: true,
+			relpath: "/proc",
+			typ:     "proc",
+			src:     "proc-build",
 		},
 		{
-			relpath:  "/sys",
-			typ:      "sysfs",
-			src:      "sysfs-build",
-			fromHost: true,
+			relpath: "/sys",
+			typ:     "sysfs",
+			src:     "sysfs-build",
 		},
 	}
 	for _, mp := range mountPoints {
-		mountCmds, umountCmds, err := getMountCmd(mp.typ, mp.src, mountDir, mp.relpath, mp.fromHost, mp.options...)
+		mountCmds, umountCmds, err := getMountCmd(mp.typ, mp.src, mountDir, mp.relpath, mp.bind, mp.options...)
 		if err != nil {
 			t.Errorf("Error preparing mountpoint \"%s\": \"%s\"",
 				mp.relpath,

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -3827,7 +3827,7 @@ func TestStateMachine_installPackages_checkcmds(t *testing.T) {
 
 	gotCmds := strings.Split(strings.TrimSpace(string(readStdout)), "\n")
 	if len(expectedCmds) != len(gotCmds) {
-		t.Fatalf("%v commands to be executed, expected %v", len(gotCmds), len(expectedCmds))
+		t.Fatalf("%v commands to be executed, expected %v commands. Got: %v", len(gotCmds), len(expectedCmds), gotCmds)
 	}
 
 	for i, gotCmd := range gotCmds {
@@ -3890,7 +3890,7 @@ func TestStateMachine_installPackages_checkcmds_failing(t *testing.T) {
 
 	gotCmds := strings.Split(strings.TrimSpace(string(readStdout)), "\n")
 	if len(expectedCmds) != len(gotCmds) {
-		t.Fatalf("%v commands to be executed, expected %v", len(gotCmds), len(expectedCmds))
+		t.Fatalf("%v commands to be executed, expected %v commands. Got: %v", len(gotCmds), len(expectedCmds), gotCmds)
 	}
 
 	for i, gotCmd := range gotCmds {

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1279,7 +1279,7 @@ func TestStateMachine_updateGrub_checkcmds(t *testing.T) {
 
 	gotCmds := strings.Split(strings.TrimSpace(string(readStdout)), "\n")
 	if len(expectedCmds) != len(gotCmds) {
-		t.Fatalf("%v commands to be executed, expected %v", len(gotCmds), len(expectedCmds))
+		t.Fatalf("%v commands to be executed, expected %v commands. Got: %v", len(gotCmds), len(expectedCmds), gotCmds)
 	}
 
 	for i, gotCmd := range gotCmds {

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1399,3 +1399,123 @@ func TestStateMachine_setConfDefDir(t *testing.T) {
 		})
 	}
 }
+
+func Test_getMountCmd(t *testing.T) {
+	type args struct {
+		typ        string
+		src        string
+		targetDir  string
+		mountpoint string
+		bind       bool
+		options    []string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantMountCmds  []string
+		wantUmountCmds []string
+		expectedError  string
+	}{
+		{
+			name: "happy path",
+			args: args{
+				typ:        "devtmps",
+				src:        "src",
+				targetDir:  "targetDir",
+				mountpoint: "mountpoint",
+				options:    []string{"nodev", "nosuid"},
+			},
+			wantMountCmds: []string{"/usr/bin/mount -t devtmps src -o nodev,nosuid targetDir/mountpoint"},
+			wantUmountCmds: []string{
+				"/usr/bin/mount --make-rprivate targetDir/mountpoint",
+				"/usr/bin/umount --recursive targetDir/mountpoint",
+			},
+		},
+		{
+			name: "no type",
+			args: args{
+				typ:        "",
+				src:        "src",
+				targetDir:  "targetDir",
+				mountpoint: "mountpoint",
+			},
+			wantMountCmds: []string{"/usr/bin/mount src targetDir/mountpoint"},
+			wantUmountCmds: []string{
+				"/usr/bin/mount --make-rprivate targetDir/mountpoint",
+				"/usr/bin/umount --recursive targetDir/mountpoint",
+			},
+		},
+		{
+			name: "bind mount",
+			args: args{
+				typ:        "",
+				src:        "src",
+				targetDir:  "targetDir",
+				mountpoint: "mountpoint",
+				bind:       true,
+			},
+			wantMountCmds: []string{"/usr/bin/mount --bind src targetDir/mountpoint"},
+			wantUmountCmds: []string{
+				"/usr/bin/mount --make-rprivate targetDir/mountpoint",
+				"/usr/bin/umount --recursive targetDir/mountpoint",
+			},
+		},
+		{
+			name: "fail with bind and type",
+			args: args{
+				typ:        "devtmps",
+				src:        "src",
+				targetDir:  "targetDir",
+				mountpoint: "mountpoint",
+				bind:       true,
+			},
+			wantMountCmds:  []string{},
+			wantUmountCmds: []string{},
+			expectedError:  "invalid mount arguments. Cannot use --bind and -t at the same time.",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			asserter := helper.Asserter{T: t}
+			gotMountCmds, gotUmountCmds, err := getMountCmd(tc.args.typ, tc.args.src, tc.args.targetDir, tc.args.mountpoint, tc.args.bind, tc.args.options...)
+
+			if len(tc.expectedError) == 0 {
+				asserter.AssertErrNil(err, true)
+			} else {
+				asserter.AssertErrContains(err, tc.expectedError)
+			}
+
+			gotMountCmdsStr := make([]string, 0)
+			gotUmountCmdsStr := make([]string, 0)
+
+			for _, c := range gotMountCmds {
+				gotMountCmdsStr = append(gotMountCmdsStr, c.String())
+			}
+
+			for _, c := range gotUmountCmds {
+				gotUmountCmdsStr = append(gotUmountCmdsStr, c.String())
+			}
+			asserter.AssertEqual(tc.wantMountCmds, gotMountCmdsStr)
+			asserter.AssertEqual(tc.wantUmountCmds, gotUmountCmdsStr)
+
+		})
+	}
+}
+
+func Test_getMountCmd_fail(t *testing.T) {
+	asserter := helper.Asserter{T: t}
+
+	// mock os.Mkdir
+	osMkdirAll = mockMkdirAll
+	t.Cleanup(func() {
+		osMkdirAll = os.MkdirAll
+	})
+	gotMountCmds, gotUmountCmds, err := getMountCmd("devtmps", "src", "/tmp", "1234567", false)
+	asserter.AssertErrContains(err, "Error creating mountpoint")
+	if gotMountCmds != nil {
+		asserter.Errorf("gotMountCmds should be nil but is %s", gotMountCmds)
+	}
+	if gotUmountCmds != nil {
+		asserter.Errorf("gotUmountCmds should be nil but is %s", gotUmountCmds)
+	}
+}

--- a/internal/statemachine/pack_test.go
+++ b/internal/statemachine/pack_test.go
@@ -382,9 +382,41 @@ func TestPackStateMachine_SuccessfulRun(t *testing.T) {
 	)
 
 	// set up the mountpoints
-	mountPoints := []string{"/dev", "/proc", "/sys"}
-	for _, mountPoint := range mountPoints {
-		mountCmds, umountCmds := mountFromHost(mountDir, mountPoint)
+	mountPoints := []mountPoint{
+		{
+			relpath:  "/dev",
+			typ:      "devtmpfs",
+			src:      "devtmpfs-build",
+			fromHost: true,
+		},
+		{
+			relpath:  "/dev/pts",
+			typ:      "devpts",
+			src:      "devpts-build",
+			options:  []string{"nodev", "nosuid"},
+			fromHost: true,
+		},
+		{
+			relpath:  "/proc",
+			typ:      "proc",
+			src:      "proc-build",
+			fromHost: true,
+		},
+		{
+			relpath:  "/sys",
+			typ:      "sysfs",
+			src:      "sysfs-build",
+			fromHost: true,
+		},
+	}
+	for _, mp := range mountPoints {
+		mountCmds, umountCmds, err := getMountCmd(mp.typ, mp.src, mountDir, mp.relpath, mp.fromHost, mp.options...)
+		if err != nil {
+			t.Errorf("Error preparing mountpoint \"%s\": \"%s\"",
+				mp.relpath,
+				err.Error(),
+			)
+		}
 		mountImageCmds = append(mountImageCmds, mountCmds...)
 		umountImageCmds = append(umountCmds, umountImageCmds...)
 	}

--- a/internal/statemachine/pack_test.go
+++ b/internal/statemachine/pack_test.go
@@ -384,33 +384,29 @@ func TestPackStateMachine_SuccessfulRun(t *testing.T) {
 	// set up the mountpoints
 	mountPoints := []mountPoint{
 		{
-			relpath:  "/dev",
-			typ:      "devtmpfs",
-			src:      "devtmpfs-build",
-			fromHost: true,
+			relpath: "/dev",
+			typ:     "devtmpfs",
+			src:     "devtmpfs-build",
 		},
 		{
-			relpath:  "/dev/pts",
-			typ:      "devpts",
-			src:      "devpts-build",
-			options:  []string{"nodev", "nosuid"},
-			fromHost: true,
+			relpath: "/dev/pts",
+			typ:     "devpts",
+			src:     "devpts-build",
+			options: []string{"nodev", "nosuid"},
 		},
 		{
-			relpath:  "/proc",
-			typ:      "proc",
-			src:      "proc-build",
-			fromHost: true,
+			relpath: "/proc",
+			typ:     "proc",
+			src:     "proc-build",
 		},
 		{
-			relpath:  "/sys",
-			typ:      "sysfs",
-			src:      "sysfs-build",
-			fromHost: true,
+			relpath: "/sys",
+			typ:     "sysfs",
+			src:     "sysfs-build",
 		},
 	}
 	for _, mp := range mountPoints {
-		mountCmds, umountCmds, err := getMountCmd(mp.typ, mp.src, mountDir, mp.relpath, mp.fromHost, mp.options...)
+		mountCmds, umountCmds, err := getMountCmd(mp.typ, mp.src, mountDir, mp.relpath, mp.bind, mp.options...)
 		if err != nil {
 			t.Errorf("Error preparing mountpoint \"%s\": \"%s\"",
 				mp.relpath,

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -240,7 +240,7 @@ func TestExecHelperProcess(t *testing.T) {
 		fallthrough
 	case "TestFailedCreateChroot":
 		fallthrough
-	case "TestFailedInstallPackages":
+	case "TestStateMachine_installPackages_fail":
 		fallthrough
 	case "TestFailedPrepareClassicImage":
 		fallthrough

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -73,8 +73,11 @@ func mockCheckEmptyFields(interface{}, *gojsonschema.Result, *jsonschema.Schema)
 func mockCheckTags(interface{}, string) (string, error) {
 	return "", fmt.Errorf("Test Error")
 }
-func mockBackupAndCopyResolvConf(string) error {
+func mockBackupAndCopyResolvConfFail(string) error {
 	return fmt.Errorf("Test Error")
+}
+func mockBackupAndCopyResolvConfSuccess(string) error {
+	return nil
 }
 func mockRestoreResolvConf(string) error {
 	return fmt.Errorf("Test Error")

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.2"
+version: "3.2+snap1"
 grade: stable
 confinement: classic
 base: core22

--- a/spread.yaml
+++ b/spread.yaml
@@ -101,7 +101,7 @@ prepare: |
   snap install core22 --channel=latest/edge
   snap install yq
   unset SHELL
-  git clone https://git.launchpad.net/ubuntu-images
+  git clone -b noble https://git.launchpad.net/ubuntu-images
   git clone https://github.com/snapcore/models
   
   snap install --classic --dangerous ./tests/ubuntu-image_*.snap

--- a/tests/classic/task.yaml
+++ b/tests/classic/task.yaml
@@ -1,12 +1,13 @@
 summary: Build classic Ubuntu server image
 
-kill-timeout: 1h
+kill-timeout: 3h
 
 environment:
     IMG/ubuntu_server_pc_amd64: ubuntu-server-pc-amd64
     # IMG/ubuntu_server_pc_arm64: ubuntu-server-pc-arm64
     IMG/ubuntu_server_pi_arm64: ubuntu-server-pi-arm64
     # IMG/ubuntu_pi_arm64: ubuntu-pi-arm64
+    IMG/edubuntu_pi_arm64: edubuntu-pi-arm64
 
 systems: [-ubuntu-18.04-64]
 


### PR DESCRIPTION
Notable changes in this PR:

- when executing some commands needing to mount some mountpoints in the chroot:
  - unmounting and "teardown" commands are now **only** executed in defer statements
  - if these commands fail, they do not prevent others from running. The goal is to hopefully unmount as many mountpoints as possible is something is going wrong. Letting some mountpoint behind is not ideal but should not prevent the image building from completing.
- run `udevadm settle` before tearing down mount points after package installation to hopefully make it more reliable
- replace bind mounts where possible. Instead directly mount `/proc` and such.
- specify the mount type to make sure mountpoints are correctly handled.
- be more granular on `/dev` mounting.

Solves LP: #2049695
