### PR TITLE
Add --import-proxy-asserts option for `snap` subcommand

### DIFF
--- a/internal/commands/snap.go
+++ b/internal/commands/snap.go
@@ -15,6 +15,7 @@ type SnapOpts struct {
 	Snaps                     []string       `long:"snap" description:"Install extra snaps. These are passed through to \"snap prepare-image\". The snap argument can include additional information about the channel and/or risk with the following syntax: <snap>=<channel|risk>" value-name:"SNAP"`
 	CloudInit                 string         `long:"cloud-init" description:"cloud-config data to be copied to the image" value-name:"USER-DATA-FILE"`
 	Revisions                 map[string]int `long:"revision" description:"The revision of a specific snap to install in the image." value-name:"REVISION"`
+	ImportProxyAsserts        string         `long:"import-proxy-asserts" description:"Import proxy assertions from the given URL" value-name:"PROXY-URL"`
 }
 
 type SnapCommand struct {


### PR DESCRIPTION
`--import-proxy-asserts` accepts a Store Proxy URL as a parameter.

Using that URL, ubuntu-image then fetches the store assertion, account-key assertion, and account assertion, needed to validate the store on a device, and appends it to `model-etc`, so that each of the assertions is imported into snapd's assertion store on first-boot.

This allows device images to be built such that they can point to a Store Proxy out of the box.