### PR TITLE
Make sure long spread tests can run in parallel 

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -19,21 +19,21 @@ backends:
     systems:
       # - ubuntu-16.04-64:
       #       workers: 1
-      #       storage: 18G
+      #       storage: 45G
       - ubuntu-18.04-64:
-            storage: 24G
+            storage: 45G
             workers: 1
       - ubuntu-20.04-64:
-            storage: 24G
+            storage: 45G
             workers: 1
       - ubuntu-22.04-64:
-            storage: 24G
+            storage: 45G
             workers: 1
       - ubuntu-23.04-64:
-            storage: 24G
+            storage: 45G
             workers: 1
       - ubuntu-23.10-64:
-            storage: 24G
+            storage: 45G
             workers: 1
   qemu:
     memory: 4G

--- a/tests/classic/task.yaml
+++ b/tests/classic/task.yaml
@@ -50,6 +50,7 @@ restore: |
 
 debug: |
     df -h
+    du -h -d 1 /tmp/
     mount  -l
     if [ -f loop.txt ]; then
         cat loop.txt


### PR DESCRIPTION
Some spread tests build "big" images (more than 10Go). Since several spread tests run in parallel on the same backend, this can fill up the current 24Go of disk. Let's raise this in hope this will be enough. 