### PR TITLE
Add support for --auto-assert option

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,12 @@
 ubuntu-image (3.3) UNRELEASED; urgency=medium
 
+  [Masahiro Nakagawa]
+  * Add auto-import option. This option allows to create image with auto-immport.assert and generates system-user account. Works only with dangerous grade image
+
+ -- Masahiro nakagawa <masahiro.nakagawa@canonical.com> Wed, 28 Feb 2024 18:01:00
+
+ubuntu-image (3.3) UNRELEASED; urgency=medium
+
   [ Masahiro Nakagawa ]
   * Add sysfs-overlay option used with --presseed option.
   * This option is required to generate a preseeding image which enhances

--- a/internal/commands/snap.go
+++ b/internal/commands/snap.go
@@ -16,6 +16,7 @@ type SnapOpts struct {
 	CloudInit                 string         `long:"cloud-init" description:"cloud-config data to be copied to the image" value-name:"USER-DATA-FILE"`
 	Revisions                 map[string]int `long:"revision" description:"The revision of a specific snap to install in the image." value-name:"REVISION"`
 	SysfsOverlay              string         `long:"sysfs-overlay" description:"The optional sysfs overlay to used for preseeding. Directories from /sys/class/* and /sys/devices/platform will be bind-mounted to the chroot when preseeding"`
+	AutoImport                string         `long:"auto-import" description:"Create a system-user account. Specify optional path to auto-import.assert. Only works with dangerous grade."`
 }
 
 type SnapCommand struct {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.3"
+version: "3.3+snap1"
 grade: stable
 confinement: classic
 base: core22

--- a/ubuntu-image.rst
+++ b/ubuntu-image.rst
@@ -114,6 +114,9 @@ model_assertion
     Specify the directory that contains the sysfs overlay. This options
     also requires the ``--preseed`` and ``--preseed-sign-key`` options.
 
+--auto-import=<path>
+    Allows to embedd auto-import.asserta specified by <path>  into generated image. Only works with dangerous grade image 
+
 Classic command options
 -----------------------
 


### PR DESCRIPTION
This option allows to embed specified auto-import.assert to generated image so that it will automatically create system-user account. This only works with dangerous grade image.