### PR TITLE
Fix mountpoint management

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.21'
+          check-latest: true
 
       - id: govulncheck
         uses: golang/govulncheck-action@v1

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -259,7 +259,7 @@ func (stateMachine *StateMachine) installPackages() error {
 	// teardownCmds should be filled as a LIFO list
 	var teardownCmds []*exec.Cmd
 
-	mountPoints := []mountPoint{}
+	mountPoints := []*mountPoint{}
 
 	// Make sure we left the system as clean as possible if something has gone wrong
 	defer func() {
@@ -268,32 +268,32 @@ func (stateMachine *StateMachine) installPackages() error {
 
 	// mount some necessary partitions in the chroot
 	mountPoints = append(mountPoints,
-		mountPoint{
+		&mountPoint{
 			src:      "devtmpfs-build",
 			basePath: stateMachine.tempDirs.chroot,
 			relpath:  "/dev",
 			typ:      "devtmpfs",
 		},
-		mountPoint{
+		&mountPoint{
 			src:      "devpts-build",
 			basePath: stateMachine.tempDirs.chroot,
 			relpath:  "/dev/pts",
 			typ:      "devpts",
 			opts:     []string{"nodev", "nosuid"},
 		},
-		mountPoint{
+		&mountPoint{
 			src:      "proc-build",
 			basePath: stateMachine.tempDirs.chroot,
 			relpath:  "/proc",
 			typ:      "proc",
 		},
-		mountPoint{
+		&mountPoint{
 			src:      "sysfs-build",
 			basePath: stateMachine.tempDirs.chroot,
 			relpath:  "/sys",
 			typ:      "sysfs",
 		},
-		mountPoint{
+		&mountPoint{
 			basePath: stateMachine.tempDirs.chroot,
 			relpath:  "/run",
 			bind:     true,
@@ -868,7 +868,7 @@ func (stateMachine *StateMachine) preseedClassicImage() (err error) {
 	var teardownCmds []*exec.Cmd
 
 	// set up the mount commands
-	mountPoints := []mountPoint{
+	mountPoints := []*mountPoint{
 		{
 			src:      "devtmpfs-build",
 			basePath: stateMachine.tempDirs.chroot,

--- a/internal/statemachine/mount_helper.go
+++ b/internal/statemachine/mount_helper.go
@@ -69,7 +69,7 @@ func teardownMount(path string, mountPoints []*mountPoint, teardownCmds []*exec.
 	if errAddedUmount != nil {
 		err = fmt.Errorf("%s\n%s", err, errAddedUmount)
 	}
-	teardownCmds = append(teardownCmds, addedUmountCmds...)
+	teardownCmds = append(addedUmountCmds, teardownCmds...)
 
 	return execTeardownCmds(teardownCmds, debug, err)
 }

--- a/internal/statemachine/mount_helper.go
+++ b/internal/statemachine/mount_helper.go
@@ -64,7 +64,7 @@ func getUnmountCmd(targetPath string) []*exec.Cmd {
 
 // teardownMount executed teardown commands after making sure every mountpoints matching the given path
 // are listed and will be properly unmounted
-func teardownMount(path string, mountPoints []mountPoint, teardownCmds []*exec.Cmd, err error, debug bool) error {
+func teardownMount(path string, mountPoints []*mountPoint, teardownCmds []*exec.Cmd, err error, debug bool) error {
 	addedUmountCmds, errAddedUmount := umountAddedMountPointsCmds(path, mountPoints)
 	if errAddedUmount != nil {
 		err = fmt.Errorf("%s\n%s", err, errAddedUmount)
@@ -75,7 +75,7 @@ func teardownMount(path string, mountPoints []mountPoint, teardownCmds []*exec.C
 }
 
 // umountAddedMountPointsCmds generates umount commands for newly added mountpoints
-func umountAddedMountPointsCmds(path string, mountPoints []mountPoint) (umountCmds []*exec.Cmd, err error) {
+func umountAddedMountPointsCmds(path string, mountPoints []*mountPoint) (umountCmds []*exec.Cmd, err error) {
 	currentMountPoints, err := listMounts(path)
 	if err != nil {
 		return nil, err
@@ -91,11 +91,11 @@ func umountAddedMountPointsCmds(path string, mountPoints []mountPoint) (umountCm
 }
 
 // diffMountPoints compares 2 lists of mountpoint and returns the added ones
-func diffMountPoints(olds []mountPoint, currents []mountPoint) (added []mountPoint) {
+func diffMountPoints(olds []*mountPoint, currents []*mountPoint) (added []*mountPoint) {
 	for _, m := range currents {
 		found := false
 		for _, o := range olds {
-			if equalMountPoints(m, o) {
+			if equalMountPoints(*m, *o) {
 				found = true
 			}
 		}
@@ -122,7 +122,7 @@ func equalMountPoints(a, b mountPoint) bool {
 }
 
 // listMounts returns mountpoints matching the given path from /proc/self/mounts
-func listMounts(path string) ([]mountPoint, error) {
+func listMounts(path string) ([]*mountPoint, error) {
 	procMounts := "/proc/self/mounts"
 	f, err := osReadFile(procMounts)
 	if err != nil {
@@ -135,8 +135,8 @@ func listMounts(path string) ([]mountPoint, error) {
 // parseMounts list existing mounts and submounts in the current path
 // The returned splice is already inverted so unmount can be called on it
 // without further modification.
-func parseMounts(procMount string, path string) ([]mountPoint, error) {
-	mountPoints := []mountPoint{}
+func parseMounts(procMount string, path string) ([]*mountPoint, error) {
+	mountPoints := []*mountPoint{}
 	mountLines := strings.Split(procMount, "\n")
 
 	for _, line := range mountLines {
@@ -151,13 +151,13 @@ func parseMounts(procMount string, path string) ([]mountPoint, error) {
 			continue
 		}
 
-		m := mountPoint{
+		m := &mountPoint{
 			src:  fields[0],
 			path: mountPath,
 			typ:  fields[2],
 			opts: strings.Split(fields[3], ","),
 		}
-		mountPoints = append([]mountPoint{m}, mountPoints...)
+		mountPoints = append([]*mountPoint{m}, mountPoints...)
 	}
 
 	return mountPoints, nil

--- a/internal/statemachine/mount_helper_test.go
+++ b/internal/statemachine/mount_helper_test.go
@@ -199,8 +199,8 @@ var (
 func Test_diffMountPoints(t *testing.T) {
 	asserter := helper.Asserter{T: t}
 	type args struct {
-		olds     []mountPoint
-		currents []mountPoint
+		olds     []*mountPoint
+		currents []*mountPoint
 	}
 
 	cmpOpts := []cmp.Option{
@@ -212,22 +212,22 @@ func Test_diffMountPoints(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want []mountPoint
+		want []*mountPoint
 	}{
 		{
 			name: "same mounpoints, ignoring list order",
 			args: args{
-				olds: []mountPoint{
-					mp1,
-					mp2,
-					mp3,
-					mp4,
+				olds: []*mountPoint{
+					&mp1,
+					&mp2,
+					&mp3,
+					&mp4,
 				},
-				currents: []mountPoint{
-					mp4,
-					mp1,
-					mp3,
-					mp2,
+				currents: []*mountPoint{
+					&mp4,
+					&mp1,
+					&mp3,
+					&mp2,
 				},
 			},
 			want: nil,
@@ -235,66 +235,66 @@ func Test_diffMountPoints(t *testing.T) {
 		{
 			name: "add some",
 			args: args{
-				olds: []mountPoint{
-					mp1,
-					mp2,
+				olds: []*mountPoint{
+					&mp1,
+					&mp2,
 				},
-				currents: []mountPoint{
-					mp3,
-					mp4,
+				currents: []*mountPoint{
+					&mp3,
+					&mp4,
 				},
 			},
-			want: []mountPoint{
-				mp3,
-				mp4,
+			want: []*mountPoint{
+				&mp3,
+				&mp4,
 			},
 		},
 		{
 			name: "no old ones",
 			args: args{
 				olds: nil,
-				currents: []mountPoint{
-					mp3,
-					mp4,
+				currents: []*mountPoint{
+					&mp3,
+					&mp4,
 				},
 			},
-			want: []mountPoint{
-				mp3,
-				mp4,
+			want: []*mountPoint{
+				&mp3,
+				&mp4,
 			},
 		},
 		{
 			name: "no current ones",
 			args: args{
-				olds: []mountPoint{
-					mp1,
-					mp2,
+				olds: []*mountPoint{
+					&mp1,
+					&mp2,
 				},
 				currents: nil,
 			},
 			want: nil,
 		},
 		{
-			name: "same src but different",
+			name: "difference in src, relpath, basepath and typ",
 			args: args{
-				olds: []mountPoint{
-					mp1,
-					mp2,
-					mp3,
-					mp4,
+				olds: []*mountPoint{
+					&mp1,
+					&mp2,
+					&mp3,
+					&mp4,
 				},
-				currents: []mountPoint{
-					mp11,
-					mp21,
-					mp31,
-					mp41,
+				currents: []*mountPoint{
+					&mp11,
+					&mp21,
+					&mp31,
+					&mp41,
 				},
 			},
-			want: []mountPoint{
-				mp11,
-				mp21,
-				mp31,
-				mp41,
+			want: []*mountPoint{
+				&mp11,
+				&mp21,
+				&mp31,
+				&mp41,
 			},
 		},
 	}

--- a/internal/statemachine/mount_helper_test.go
+++ b/internal/statemachine/mount_helper_test.go
@@ -70,6 +70,21 @@ func Test_getMountCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "no src",
+			mp: mountPoint{
+				src:      "",
+				basePath: "targetDir",
+				relpath:  "mountpoint",
+				typ:      "",
+				bind:     true,
+			},
+			wantMountCmds: []string{"/usr/bin/mount --bind  targetDir/mountpoint"},
+			wantUmountCmds: []string{
+				"/usr/bin/mount --make-rprivate targetDir/mountpoint",
+				"/usr/bin/umount --recursive targetDir/mountpoint",
+			},
+		},
+		{
 			name: "fail with bind and type",
 			mp: mountPoint{
 				src:      "src",

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.3+snap3"
+version: "3.3+snap4"
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
When running ubuntu-image outside of the snap (after building it locally and running the binary) the build is failing with an error very similar to the one we tried to solve in https://github.com/canonical/ubuntu-image/pull/183. But this time it fails during preseeding and mounting/umouting is done by snapd. I cannot reproduce the error today... 

For now I was unable to reproduce with the snap so I suspect this is linked to my local snapd. 

Anyway, this error also showed that we do not umount mountpoints in the right order (newly found ones are not unmounted first) and we do not properly update mountpoints using `bind: true`). This PR solves both these issues.

I am still investigating why this is failing outside the snap but this is probably not critical since we only distribute ubuntu-image as a  snap.