### PR TITLE
Add Snap Store badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # ubuntu-image: build Ubuntu images
 
+[![ubuntu-image](https://snapcraft.io/ubuntu-image/badge.svg)](https://snapcraft.io/ubuntu-image)
 ![Build](https://github.com/canonical/ubuntu-image/actions/workflows/build-and-test.yml/badge.svg)
 [![codecov](https://codecov.io/gh/canonical/ubuntu-image/branch/main/graph/badge.svg?token=F9jE9HKo1a)](https://codecov.io/gh/canonical/ubuntu-image)
 [![Go Report Card](https://goreportcard.com/badge/github.com/canonical/ubuntu-image)](https://goreportcard.com/report/github.com/canonical/ubuntu-image)
+
 
 ubuntu-image is used to build the following Ubuntu images:
 
@@ -29,3 +31,4 @@ Ubuntu 18.04 (Bionic Beaver) is the minimum platform requirement, but Ubuntu 20.
 ## Building & testing
 
 For instructions on building and testing ubuntu-image, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+


### PR DESCRIPTION
One-liner to add the Snap Store badge.

(It's not possible to include the entire badge that contains version info etc. because it uses `iframe`, which GitHub doesn't allow.)