### PR TITLE
Add a dry-run mode to only display states that would be executed

### DIFF
--- a/cmd/ubuntu-image/main.go
+++ b/cmd/ubuntu-image/main.go
@@ -51,7 +51,6 @@ func initStateMachine(imageType string, commonOpts *commands.CommonOpts, stateMa
 }
 
 func executeStateMachine(sm statemachine.SmInterface) error {
-	// set up, run, and tear down the state machine
 	if err := sm.Setup(); err != nil {
 		return err
 	}

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ ubuntu-image (3.4) UNRELEASED; urgency=medium
   [ Paul Mars ]
   * Enable not setting any artifact in the image definition
   * Make the resume feature more reliable
+  * Add a --dry-run flag to only display that would be executed and exit
 
  -- Paul Mars <paul.mars@canonical.com>  Fri, 08 Mar 2024 16:02:07 +0100
 

--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -14,6 +14,7 @@ type CommonOpts struct {
 	Channel    string `short:"c" long:"channel" description:"The default snap channel to use" value-name:"CHANNEL"`
 	SectorSize string `long:"sector-size" description:"Sector size to use when creating the disk image. Only 512 and 4k sector sizes are supported." choice:"512" choice:"4096" value-name:"SECTOR-SIZE" default:"512"`
 	Validation string `long:"validation" description:"Control whether validations should be ignored or enforced" choice:"ignore" choice:"enforce"`
+	DryRun     bool   `long:"dry-run" description:"Print the states to be executed to build the image and return."`
 }
 
 // StateMachineOpts stores the options that are related to the state machine

--- a/internal/statemachine/classic.go
+++ b/internal/statemachine/classic.go
@@ -66,17 +66,17 @@ func (classicStateMachine *ClassicStateMachine) Setup() error {
 		return err
 	}
 
+	classicStateMachine.displayStates()
+
+	if classicStateMachine.commonFlags.DryRun {
+		return nil
+	}
+
 	if err := classicStateMachine.makeTemporaryDirectories(); err != nil {
 		return err
 	}
 
-	if err := classicStateMachine.determineOutputDirectory(); err != nil {
-		return err
-	}
-
-	classicStateMachine.displayStates()
-
-	return nil
+	return classicStateMachine.determineOutputDirectory()
 }
 
 // parseImageDefinition parses the provided yaml file and ensures it is valid

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -511,8 +511,8 @@ func TestFailedCalculateStates(t *testing.T) {
 	asserter.AssertErrContains(err, "Test Error")
 }
 
-// TestPrintStates ensures the states are printed to stdout when the --debug flag is set
-func TestPrintStates(t *testing.T) {
+// TestDisplayStates ensures the states are printed to stdout when the --debug flag is set
+func TestDisplayStates(t *testing.T) {
 	asserter := helper.Asserter{T: t}
 	restoreCWD := helper.SaveCWD()
 	defer restoreCWD()

--- a/internal/statemachine/pack.go
+++ b/internal/statemachine/pack.go
@@ -49,11 +49,11 @@ func (packStateMachine *PackStateMachine) Setup() error {
 		return err
 	}
 
-	if err := packStateMachine.makeTemporaryDirectories(); err != nil {
-		return err
-	}
-
 	packStateMachine.displayStates()
 
-	return nil
+	if packStateMachine.commonFlags.DryRun {
+		return nil
+	}
+
+	return packStateMachine.makeTemporaryDirectories()
 }

--- a/internal/statemachine/snap.go
+++ b/internal/statemachine/snap.go
@@ -25,8 +25,7 @@ type SnapStateMachine struct {
 	Args commands.SnapArgs
 }
 
-// Setup assigns variables and calls other functions that must be executed before Run(). It is
-// exported so it can be used as a polymorphism in main
+// Setup assigns variables and calls other functions that must be executed before Run().
 func (snapStateMachine *SnapStateMachine) Setup() error {
 	// set the parent pointer of the embedded struct
 	snapStateMachine.parent = snapStateMachine

--- a/internal/statemachine/snap.go
+++ b/internal/statemachine/snap.go
@@ -53,15 +53,15 @@ func (snapStateMachine *SnapStateMachine) Setup() error {
 		return err
 	}
 
+	snapStateMachine.displayStates()
+
+	if snapStateMachine.commonFlags.DryRun {
+		return nil
+	}
+
 	if err := snapStateMachine.makeTemporaryDirectories(); err != nil {
 		return err
 	}
 
-	if err := snapStateMachine.determineOutputDirectory(); err != nil {
-		return err
-	}
-
-	snapStateMachine.displayStates()
-
-	return nil
+	return snapStateMachine.determineOutputDirectory()
 }

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -417,10 +417,16 @@ func rebuildYamlIndex(info *gadget.Info) {
 
 // displayStates print the calculated states
 func (s *StateMachine) displayStates() {
-	if !s.commonFlags.Debug {
+	if !s.commonFlags.Debug && !s.commonFlags.DryRun {
 		return
 	}
-	fmt.Println("\nFollowing states will be executed:")
+
+	verb := "will"
+	if s.commonFlags.DryRun {
+		verb = "would"
+	}
+	fmt.Printf("\nFollowing states %s be executed:\n", verb)
+
 	for i, state := range s.states {
 		if state.name == s.stateMachineFlags.Until {
 			break
@@ -430,6 +436,10 @@ func (s *StateMachine) displayStates() {
 		if state.name == s.stateMachineFlags.Thru {
 			break
 		}
+	}
+
+	if s.commonFlags.DryRun {
+		return
 	}
 	fmt.Println("\nContinuing")
 }
@@ -530,6 +540,9 @@ func (stateMachine *StateMachine) determineOutputDirectory() error {
 
 // Run iterates through the state functions, stopping when appropriate based on --until and --thru
 func (stateMachine *StateMachine) Run() error {
+	if stateMachine.commonFlags.DryRun {
+		return nil
+	}
 	// iterate through the states
 	for i := 0; i < len(stateMachine.states); i++ {
 		stateFunc := stateMachine.states[i]
@@ -564,6 +577,9 @@ func (stateMachine *StateMachine) Run() error {
 
 // Teardown handles anything else that needs to happen after the states have finished running
 func (stateMachine *StateMachine) Teardown() error {
+	if stateMachine.commonFlags.DryRun {
+		return nil
+	}
 	if stateMachine.cleanWorkDir {
 		return stateMachine.cleanup()
 	}

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -339,7 +339,7 @@ func TestUntilThru(t *testing.T) {
 func TestDebug(t *testing.T) {
 	asserter := helper.Asserter{T: t}
 	workDir := "ubuntu-image-test-debug"
-	if err := os.Mkdir("ubuntu-image-test-debug", 0755); err != nil {
+	if err := os.Mkdir(workDir, 0755); err != nil {
 		t.Errorf("Failed to create temporary directory %s\n", workDir)
 	}
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.3+snap4"
+version: "3.3+snap5"
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
Add a dry-run mode to only display states that would be executed to help users understand what is going to happen based on the given configuration and flags.

Fixes: FR-7037