### PR TITLE
Preseed and update-grub failing to unmount some directories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 
 require (
 	github.com/snapcore/secboot v0.0.0-20230623151406-4d331d24f830 // indirect
-	github.com/snapcore/snapd v0.0.0-20240307091342-db276493400d
+	github.com/snapcore/snapd v0.0.0-20240403130118-9134ef8daa86
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/snapcore/go-gettext v0.0.0-20230721153050-9082cdc2db05/go.mod h1:1ueM
 github.com/snapcore/secboot v0.0.0-20230623151406-4d331d24f830 h1:SCJ9Uiekv6uMqzMGP50Y0KBxkLP7IzPW35aI3Po6iyM=
 github.com/snapcore/secboot v0.0.0-20230623151406-4d331d24f830/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
-github.com/snapcore/snapd v0.0.0-20240307091342-db276493400d h1:PdKI1zJXDsPWc02r3kJ+KXLLiWm3JbZuyOmMsQacoMs=
-github.com/snapcore/snapd v0.0.0-20240307091342-db276493400d/go.mod h1:fNxLckWb4/vy0xM4i7edcRh0+PlqoEL59Pyk6QcG7us=
+github.com/snapcore/snapd v0.0.0-20240403130118-9134ef8daa86 h1:MFHyLaoqd8wrNiNZd8uzQBmvm0WMTmmU3T55VaLi1x0=
+github.com/snapcore/snapd v0.0.0-20240403130118-9134ef8daa86/go.mod h1:fNxLckWb4/vy0xM4i7edcRh0+PlqoEL59Pyk6QcG7us=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -1003,6 +1003,10 @@ func (stateMachine *StateMachine) preseedClassicImage() (err error) {
 		teardownCmds = append(umountCmds, teardownCmds...)
 	}
 
+	teardownCmds = append([]*exec.Cmd{
+		execCommand("udevadm", "settle"),
+	}, teardownCmds...)
+
 	preseedCmds = append(preseedCmds,
 		//nolint:gosec,G204
 		exec.Command("/usr/lib/snapd/snap-preseed", stateMachine.tempDirs.chroot),

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2022,7 +2022,7 @@ func TestPrepareClassicImage(t *testing.T) {
 	var stateMachine ClassicStateMachine
 	stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
 	stateMachine.parent = &stateMachine
-	stateMachine.Snaps = []string{"lxd"}
+	stateMachine.Snaps = []string{"core20"}
 	stateMachine.commonFlags.Channel = "stable"
 	stateMachine.ImageDef = imagedefinition.ImageDefinition{
 		Architecture: getHostArch(),
@@ -2033,7 +2033,11 @@ func TestPrepareClassicImage(t *testing.T) {
 					Channel:  "candidate",
 				},
 				{
-					SnapName: "core20",
+					SnapName: "lxd",
+					Channel:  "latest/stable",
+				},
+				{
+					SnapName: "core22",
 				},
 			},
 		},
@@ -2049,7 +2053,7 @@ func TestPrepareClassicImage(t *testing.T) {
 
 	// check that the lxd and hello snaps, as well as lxd's base, core20
 	// were prepared in the correct location
-	snaps := map[string]string{"lxd": "stable", "hello": "candidate", "core20": "stable"}
+	snaps := map[string]string{"lxd": "stable", "hello": "candidate", "core20": "stable", "core22": "stable"}
 	for snapName, snapChannel := range snaps {
 		// reach out to the snap store to find the revision
 		// of the snap for the specified channel

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -1124,6 +1124,10 @@ func (stateMachine *StateMachine) updateGrub(rootfsVolName string, rootfsPartNum
 		teardownCmds = append(umountCmds, teardownCmds...)
 	}
 
+	teardownCmds = append([]*exec.Cmd{
+		execCommand("udevadm", "settle"),
+	}, teardownCmds...)
+
 	divert, undivert := divertOSProber(mountDir)
 
 	updateGrubCmds = append(updateGrubCmds, divert)

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1138,6 +1138,7 @@ func TestStateMachine_updateGrub_checkcmds(t *testing.T) {
 		regexp.MustCompile("^chroot .*/scratch/loopback dpkg-divert"),
 		regexp.MustCompile("^chroot .*/scratch/loopback update-grub$"),
 		regexp.MustCompile("^chroot .*/scratch/loopback dpkg-divert --remove"),
+		regexp.MustCompile("^udevadm settle$"),
 		regexp.MustCompile("^mount --make-rprivate .*/scratch/loopback/sys$"),
 		regexp.MustCompile("^umount --recursive .*scratch/loopback/sys$"),
 		regexp.MustCompile("^mount --make-rprivate .*/scratch/loopback/proc$"),

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.3+snap7"
+version: "3.3+snap8"
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
Some steps requiring mounting/umounting the chroot and some other specific system dirs (/proc, etc.) are still sometimes failing due to a race condition in device management.

This fix applies the same `udevdam settle` fix to hopefully make this more robust.

Also update snapd because some fixes around preseeding where merged since the last update. 



Fixes: FR-7189
Fixes: LP #2058629