### PR TITLE
Fix gpg tmp dir path

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,9 @@ ubuntu-image (3.4) UNRELEASED; urgency=medium
   * Enable not setting any artifact in the image definition
   * Make the resume feature more reliable
   * Add a --dry-run flag to only display what would be executed and exit
-  * Refactor several functions to improve readability and maintainability 
+  * Refactor several functions to improve readability and maintainability
+  * Display a clear message when gpg would fail to import PPA keys and help
+    users solve the issue until the root cause is fixed
 
  -- Paul Mars <paul.mars@canonical.com>  Fri, 08 Mar 2024 16:02:07 +0100
 

--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -21,7 +21,7 @@ type CommonOpts struct {
 
 // StateMachineOpts stores the options that are related to the state machine
 type StateMachineOpts struct {
-	WorkDir string `short:"w" long:"workdir" description:"The working directory in which to download and unpack all the source files for the image. This directory can exist or not, and it is not removed after this program exits. If not given, a temporary working directory is used instead, which *is* deleted after this program exits. Use -w if you want to be able to resume a partial state machine run." value-name:"DIRECTORY" group:"State Machine Options" default:""`
+	WorkDir string `short:"w" long:"workdir" description:"The working directory in which to download and unpack all the source files for the image. This directory can exist or not, and it is not removed after this program exits. If not given, a temporary working directory is used instead, which *is* deleted after this program exits. Use -w if you want to be able to resume a partial state machine run. Note: due to a current limitation, the resulting absolute path of the workdir cannot be longer than 80 characters." value-name:"DIRECTORY" group:"State Machine Options" default:""`
 	Until   string `short:"u" long:"until" description:"Run the state machine until the given STEP, non-inclusively. STEP must be the name of the step." value-name:"STEP" default:""`
 	Thru    string `short:"t" long:"thru" description:"Run the state machine through the given STEP, inclusively. STEP must be the name of the step." value-name:"STEP" default:""`
 	Resume  bool   `short:"r" long:"resume" description:"Continue the state machine from the previously saved state. It is an error if there is no previous state."`

--- a/internal/ppa/ppa.go
+++ b/internal/ppa/ppa.go
@@ -252,7 +252,7 @@ func (p *BasePPA) ensureFingerprint(baseURL string) error {
 }
 
 func (p *BasePPA) createTmpGPGDir(basePath string) (string, error) {
-	tmpGPGDir := filepath.Join(basePath, "tmp", "ubuntu-image-gpg")
+	tmpGPGDir := filepath.Join(basePath, "tmp", "u-i-gpg")
 	err := osMkdirAll(tmpGPGDir, 0755)
 	if err != nil && !os.IsExist(err) {
 		return "", fmt.Errorf("Error creating temp dir for gpg imports: %s", err.Error())

--- a/internal/ppa/ppa.go
+++ b/internal/ppa/ppa.go
@@ -253,6 +253,14 @@ func (p *BasePPA) ensureFingerprint(baseURL string) error {
 
 func (p *BasePPA) createTmpGPGDir(basePath string) (string, error) {
 	tmpGPGDir := filepath.Join(basePath, "tmp", "u-i-gpg")
+
+	// dirmngr cannot handle a homedir path length of 100 or above
+	// Until this is fixed, return a user-friendly error.
+	// See LP: #2057885
+	if len(tmpGPGDir) >= 100 {
+		return "", fmt.Errorf("dirmngr cannot handle a homedir path length of 100 or above. Please move your workdir somewhere else to have a shorter path. Current path: %s", tmpGPGDir)
+	}
+
 	err := osMkdirAll(tmpGPGDir, 0755)
 	if err != nil && !os.IsExist(err) {
 		return "", fmt.Errorf("Error creating temp dir for gpg imports: %s", err.Error())

--- a/internal/ppa/ppa_test.go
+++ b/internal/ppa/ppa_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -344,6 +345,14 @@ func TestAdd_fail(t *testing.T) {
 	gpgDir := filepath.Join(tmpDirPath, trustedGPGDPath)
 	err = os.MkdirAll(gpgDir, 0755)
 	asserter.AssertErrNil(err, true)
+
+	longName := strings.Repeat("a", 100)
+	longTmpDirPath, err := os.MkdirTemp("/tmp", longName)
+	asserter.AssertErrNil(err, true)
+	t.Cleanup(func() { os.RemoveAll(longTmpDirPath) })
+
+	err = p.Add(longTmpDirPath, true)
+	asserter.AssertErrContains(err, "dirmngr cannot handle a homedir path length of 100 or above")
 
 	osMkdirAll = mockMkdirAll
 	t.Cleanup(func() {

--- a/internal/ppa/ppa_test.go
+++ b/internal/ppa/ppa_test.go
@@ -253,7 +253,7 @@ func TestLegacyAddRemove(t *testing.T) {
 	asserter.AssertErrNil(err, true)
 	asserter.AssertEqual(legacyPPA2Content, string(ppaBytes))
 
-	tmpGPGDir := filepath.Join(tmpDirPath, "tmp", "ubuntu-image-gpg")
+	tmpGPGDir := filepath.Join(tmpDirPath, "tmp", "u-i-gpg")
 	_, err = os.Stat(tmpGPGDir)
 	if !os.IsNotExist(err) {
 		t.Errorf("Dir %s should not exist, but does", tmpGPGDir)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.3+snap8"
+version: "3.3+snap9"
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
dirmngr, called by gpg when importing a PPA key, cannot handle a homedir path length of 100 or above. Until this is fixed, return a user-friendly error to help users avoid the issue.

Also use a shorter name for the tmp dir so the issue is less likely to happen.

Fixes: LP: #2057885