### PR TITLE
Set the appropriate pocket in the security entry in sources list file with Deb822 format

### DIFF
--- a/internal/imagedefinition/image_definition.go
+++ b/internal/imagedefinition/image_definition.go
@@ -491,7 +491,7 @@ func (i *ImageDefinition) deb822SourcesList(target bool) string {
 		i.securityMirror(),
 		i.Series,
 		i.Rootfs.Components,
-		pocket,
+		SECURITY_POCKET,
 	)
 
 	return ubuntuSources

--- a/internal/imagedefinition/image_definition.go
+++ b/internal/imagedefinition/image_definition.go
@@ -315,6 +315,14 @@ func (i ImageDefinition) securityMirror() string {
 	return i.Rootfs.Mirror
 }
 
+// List of valid pockets
+const (
+	RELEASE_POCKET  = "release"
+	SECURITY_POCKET = "security"
+	UPDATES_POCKET  = "updates"
+	PROPOSED_POCKET = "proposed"
+)
+
 // generateLegacySourcesList returns the content to write to the sources.list file
 // under the legacy format.
 func generateLegacySourcesList(series string, components []string, mirror string, securityMirror string, pocket string) string {
@@ -335,13 +343,13 @@ func generateLegacySourcesList(series string, components []string, mirror string
 	sourcesList := make([]string, 0)
 
 	switch pocket {
-	case "release":
+	case RELEASE_POCKET:
 		sourcesList = append(sourcesList, releaseSource)
-	case "security":
+	case SECURITY_POCKET:
 		sourcesList = append(sourcesList, releaseSource, securitySource)
-	case "updates":
+	case UPDATES_POCKET:
 		sourcesList = append(sourcesList, releaseSource, securitySource, updatesSource)
-	case "proposed":
+	case PROPOSED_POCKET:
 		sourcesList = append(sourcesList, releaseSource, securitySource, updatesSource, proposedSource)
 	}
 
@@ -391,15 +399,15 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 	suites := make([]string, 0)
 
 	switch pocket {
-	case "security":
+	case SECURITY_POCKET:
 		suites = []string{series + "-security"}
-	case "proposed":
+	case PROPOSED_POCKET:
 		suites = append([]string{series + "-proposed"}, suites...)
 		fallthrough
-	case "updates":
+	case UPDATES_POCKET:
 		suites = append([]string{series + "-updates"}, suites...)
 		fallthrough
-	case "release":
+	case RELEASE_POCKET:
 		suites = append([]string{series}, suites...)
 	}
 

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2515,7 +2515,7 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 ## this should mirror your choices in the previous section.
 Types: deb
 URIs: http://security.ubuntu.com/ubuntu/
-Suites: jammy
+Suites: jammy-security
 Components: main restricted
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
@@ -3342,7 +3342,7 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 ## this should mirror your choices in the previous section.
 Types: deb
 URIs: http://security.ubuntu.com/ubuntu/
-Suites: jammy jammy-updates jammy-proposed
+Suites: jammy-security
 Components: main universe restricted
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
@@ -4148,7 +4148,7 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 ## this should mirror your choices in the previous section.
 Types: deb
 URIs: http://security.ubuntu.com/ubuntu/
-Suites: jammy jammy-updates jammy-proposed
+Suites: jammy-security
 Components: main restricted
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 


### PR DESCRIPTION
When using the deb822 format, we add an entry for the security pocket with a specific mirror. This entry now correctly the `security` pocket.

As a bonus, now a proper list of existing pockets is defined to make it easily usable and less error prone.  