### PR TITLE
Auto import assertion

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -38,6 +38,11 @@ ubuntu-image (3.5) UNRELEASED; urgency=medium
 
  -- Paul Mars <paul.mars@canonical.com>  Fri, 19 Apr 2024 15:53:14 +0200
  
+  [Masahiro Nakagawa]
+  * Add auto-import option. This option allows to create image with auto-immport.assert and generates system-user account. Works only with dangerous grade image
+
+ -- Masahiro nakagawa <masahiro.nakagawa@canonical.com> Wed,158 May 2024 18:01:00
+
 ubuntu-image (3.4) UNRELEASED; urgency=medium
 
   [ Paul Mars ]

--- a/internal/commands/snap.go
+++ b/internal/commands/snap.go
@@ -17,6 +17,7 @@ type SnapOpts struct {
 	CloudInit                 string         `long:"cloud-init" description:"cloud-config data to be copied to the image" value-name:"USER-DATA-FILE"`
 	Revisions                 map[string]int `long:"revision" description:"The revision of a specific snap to install in the image." value-name:"REVISION"`
 	SysfsOverlay              string         `long:"sysfs-overlay" description:"The optional sysfs overlay to used for preseeding. Directories from /sys/class/* and /sys/devices/platform will be bind-mounted to the chroot when preseeding"`
+        AutoImport                string         `long:"auto-import" description:"Create a system-user account. Specify optional path to auto-import.assert. Only works with dangerous grade."`    
 }
 
 type SnapCommand struct {

--- a/internal/statemachine/snap_test.go
+++ b/internal/statemachine/snap_test.go
@@ -974,3 +974,51 @@ func TestSnapStateMachine_decodeModelAssertion(t *testing.T) {
 		})
 	}
 }
+
+func TestAutoImportFlag(t *testing.T) {
+	asserter := helper.Asserter{T: t}
+	restoreCWD := testhelper.SaveCWD()
+	defer restoreCWD()
+
+	var calledOpts *image.Options
+	imagePrepare = func(opts *image.Options) error {
+		calledOpts = opts
+		return nil
+	}
+	defer func() {
+		imagePrepare = image.Prepare
+	}()
+
+	var stateMachine SnapStateMachine
+	stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+	stateMachine.parent = &stateMachine
+	stateMachine.Args.ModelAssertion = filepath.Join("testdata", "modelAssertionValidation")
+	workDir, err := os.MkdirTemp("/tmp", "ubuntu-image-")
+	asserter.AssertErrNil(err, true)
+	t.Cleanup(func() { os.RemoveAll(workDir) })
+	stateMachine.stateMachineFlags.WorkDir = workDir
+	stateMachine.stateMachineFlags.Thru = "prepare_image"
+	stateMachine.Opts.Preseed = false
+	stateMachine.Opts.AutoImport = "auto-import.assert"
+	err = stateMachine.Setup()
+	asserter.AssertErrNil(err, true)
+
+	err = stateMachine.Run()
+	asserter.AssertErrNil(err, true)
+
+	if calledOpts == nil {
+		t.Errorf("options passed to image.Prepare are nil")
+	}
+
+	if calledOpts.AutoImport == "" {
+		t.Error("Expected Auto import assertion name is not null")
+	}
+	/*
+		expectedAssertionName := "auto-import.assert"
+		if calledOpts.AutoImport != expectedAssertionName {
+			t.Errorf("Expected auto import assertion name to be %q, but it's %q", expectedAssertionName, calledOpts.AutoImport)
+		}
+	*/
+	err = stateMachine.Teardown()
+	asserter.AssertErrNil(err, true)
+}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.6.0"
+version: "3.6.0+snap1"
 grade: stable
 confinement: classic
 base: core24


### PR DESCRIPTION
Add --auto-import option to create a dangerous image with specified system-user assertion.