### PR TITLE
Set gpt partition as bootable if associated to system-boot role

### DIFF
--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -35,6 +35,8 @@ const (
 	schemaGPT = "gpt"
 
 	bareStructure = "bare"
+
+	gptBootableAttribute uint64 = 4
 )
 
 var runCmd = helper.RunCmd
@@ -515,12 +517,18 @@ func gptPartitionFromStruct(structure gadget.VolumeStructure, sectorSize uint64,
 		partitionName = "writable"
 	}
 
-	return &gpt.Partition{
+	partition := &gpt.Partition{
 		Start: uint64(math.Ceil(float64(*structure.Offset) / float64(sectorSize))),
 		Size:  uint64(structure.Size),
 		Type:  gpt.Type(structureType),
 		Name:  partitionName,
 	}
+
+	if structure.Role == gadget.SystemBoot || structure.Label == gadget.SystemBoot {
+		partition.Attributes = gptBootableAttribute
+	}
+
+	return partition
 }
 
 // copyDataToImage runs dd commands to copy the raw data to the final image with appropriate offsets


### PR DESCRIPTION
Make sure gpt partitions associated to a system-boot role have the bootable attribute set. This was missing and was problematic because uboot failed to find the partition to boot on. 