### PR TITLE
Use a valid cloud-init user-data config in the image definition example

### DIFF
--- a/internal/imagedefinition/README.rst
+++ b/internal/imagedefinition/README.rst
@@ -513,8 +513,12 @@ Raspberry Pi images is:
     cloud-init:
       user-data: |
         #cloud-config
-        name: ubuntu
-        password: ubuntu
+        chpasswd:
+          expire: true
+          users:
+            - name: ubuntu
+              password: ubuntu
+              type: text
     extra-snaps:
       - name: snapd
     fstab:


### PR DESCRIPTION
Previous configuration was deprecated/invalid and resulted in a example generating an image impossible to login to with the ubuntu account (because the password was never set).