### PR TITLE
internal/statemachine: improve handling of non-fs structures

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,9 @@ ubuntu-image (3.5) UNRELEASED; urgency=medium
   * Improve validation and overall handling of volumes from the
     gadget.yaml. 
 
+  [ Maciej Borzecki ]
+  * Improve handling of structures without a filesystem.
+
  -- Paul Mars <paul.mars@canonical.com>  Fri, 19 Apr 2024 15:53:14 +0200
  
 ubuntu-image (3.4) UNRELEASED; urgency=medium

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -33,8 +33,6 @@ const (
 	schemaMBR = "mbr"
 	// schemaGPT identifies a GUID Partition Table partitioning schema
 	schemaGPT = "gpt"
-
-	bareStructure = "bare"
 )
 
 var runCmd = helper.RunCmd
@@ -454,8 +452,7 @@ func generatePartitionTable(volume *gadget.Volume, sectorSize uint64, isSeeded b
 	partitionNumber, rootfsPartitionNumber := 1, -1
 
 	for _, structure := range volume.Structure {
-		if structure.Role == schemaMBR || structure.Type == bareStructure ||
-			shouldSkipStructure(structure, isSeeded) {
+		if !structure.IsPartition() || shouldSkipStructure(structure, isSeeded) {
 			continue
 		}
 

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -174,7 +174,8 @@ func (stateMachine *StateMachine) copyStructureContent(volume *gadget.Volume,
 	structure gadget.VolumeStructure, structIndex int,
 	contentRoot, partImg string) error {
 
-	if structure.Filesystem == "" {
+	if !structure.HasFilesystem() {
+		// binary blobs like eg. raw bootloader images
 		err := copyStructureNoFS(stateMachine.tempDirs.unpack, structure, partImg)
 		if err != nil {
 			return err

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -259,9 +259,9 @@ func TestFailedCopyStructureContent(t *testing.T) {
 
 	// mock helper.CopyBlob and test with no filesystem specified
 	helperCopyBlob = mockCopyBlob
-	defer func() {
+	t.Cleanup(func() {
 		helperCopyBlob = helper.CopyBlob
-	}()
+	})
 	err = stateMachine.copyStructureContent(volume, mbrStruct, 0, "",
 		filepath.Join("/tmp", uuid.NewString()+".img"))
 	asserter.AssertErrContains(err, "Error zeroing partition")
@@ -269,9 +269,9 @@ func TestFailedCopyStructureContent(t *testing.T) {
 
 	// set an invalid blocksize to mock the binary copy blob
 	blockSize = "0"
-	defer func() {
+	t.Cleanup(func() {
 		blockSize = "1"
-	}()
+	})
 	err = stateMachine.copyStructureContent(volume, mbrStruct, 0, "",
 		filepath.Join("/tmp", uuid.NewString()+".img"))
 	asserter.AssertErrContains(err, "Error copying image blob")
@@ -279,9 +279,9 @@ func TestFailedCopyStructureContent(t *testing.T) {
 
 	// mock helper.CopyBlob and test with filesystem: vfat
 	helperCopyBlob = mockCopyBlob
-	defer func() {
+	t.Cleanup(func() {
 		helperCopyBlob = helper.CopyBlob
-	}()
+	})
 	err = stateMachine.copyStructureContent(volume, rootfsStruct, 0, "",
 		filepath.Join("/tmp", uuid.NewString()+".img"))
 	asserter.AssertErrContains(err, "Error zeroing image file")
@@ -289,9 +289,9 @@ func TestFailedCopyStructureContent(t *testing.T) {
 
 	// mock os.ReadDir
 	osReadDir = mockReadDir
-	defer func() {
+	t.Cleanup(func() {
 		osReadDir = os.ReadDir
-	}()
+	})
 	err = stateMachine.copyStructureContent(volume, rootfsStruct, 0, "",
 		filepath.Join("/tmp", uuid.NewString()+".img"))
 	asserter.AssertErrContains(err, "Error listing contents of volume")
@@ -319,9 +319,9 @@ func TestFailedCopyStructureContent(t *testing.T) {
 
 	// mock gadget.MkfsWithContent
 	mkfsMakeWithContent = mockMkfsWithContent
-	defer func() {
+	t.Cleanup(func() {
 		mkfsMakeWithContent = mkfs.MakeWithContent
-	}()
+	})
 	err = stateMachine.copyStructureContent(volume, rootfsStruct, 0, "",
 		filepath.Join("/tmp", uuid.NewString()+".img"))
 	asserter.AssertErrContains(err, "Error running mkfs with content")
@@ -330,9 +330,9 @@ func TestFailedCopyStructureContent(t *testing.T) {
 	// mock mkfs.Mkfs
 	rootfsStruct.Content = nil // to trigger the "empty partition" case
 	mkfsMake = mockMkfs
-	defer func() {
+	t.Cleanup(func() {
 		mkfsMake = mkfs.Make
-	}()
+	})
 	err = stateMachine.copyStructureContent(volume, rootfsStruct, 0, "",
 		filepath.Join("/tmp", uuid.NewString()+".img"))
 	asserter.AssertErrContains(err, "Error running mkfs")

--- a/internal/statemachine/testdata/gadget-no-fs.yaml
+++ b/internal/statemachine/testdata/gadget-no-fs.yaml
@@ -1,0 +1,8 @@
+volumes:
+  pc:
+    bootloader: grub
+    structure:
+      - name: placeholder
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        filesystem: none
+        size: 50M

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.4+snap5"
+version: "3.4+snap6"
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
There was a customer ticket reported where they included a structure that had no filesystem. The [reference](https://snapcraft.io/docs/the-gadget-snap) mentions that the volume.structure.[x].filesystem attribute takes values: `none | fat16 |  vfat | ext4`, but specifying `none` did not work for them.

Use the helpers provided by snapd for checking whether a structure has a filesystem or should be present in the partition table. 

Also some drive by fixes for using t.Cleanup()
