### PR TITLE
GPT header rework - Refacto 1

### DIFF
--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -153,7 +153,7 @@ func (stateMachine *StateMachine) calculateRootfsSize() error {
 
 	if stateMachine.commonFlags.Size != "" {
 		rootfsVolume, rootfsVolumeName := stateMachine.findRootfsVolume()
-		desiredSize := stateMachine.getSuggestedImageSize(rootfsVolumeName)
+		desiredSize := stateMachine.ImageSizes[rootfsVolumeName]
 
 		// subtract the size and offsets of the existing volumes
 		if rootfsVolume != nil {

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -857,15 +857,6 @@ func TestFailedMakeDisk(t *testing.T) {
 	asserter.AssertErrContains(err, "Error creating disk image")
 	diskfsCreate = diskfs.Create
 
-	// mock os.Truncate
-	osTruncate = mockTruncate
-	defer func() {
-		osTruncate = os.Truncate
-	}()
-	err = stateMachine.makeDisk()
-	asserter.AssertErrContains(err, "Error resizing disk image")
-	osTruncate = os.Truncate
-
 	// mock diskfs.Create to create a read only disk
 	diskfsCreate = readOnlyDiskfsCreate
 	defer func() {

--- a/internal/statemachine/common_test.go
+++ b/internal/statemachine/common_test.go
@@ -609,7 +609,7 @@ func TestFailedPopulatePreparePartitions(t *testing.T) {
 	osMkdir = os.Mkdir
 }
 
-// TestEmptyPartPopulatePreparePartitions performs a successful run a gadget.yaml that has,
+// TestEmptyPartPopulatePreparePartitions performs a successful run with a gadget.yaml that has,
 // besides regular partitions, one empty partition and makes sure that a partition image file
 // has been created for it (LP: #1947863)
 func TestEmptyPartPopulatePreparePartitions(t *testing.T) {

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -309,6 +309,8 @@ func hasContent(structure gadget.VolumeStructure, contentRoot string) (bool, err
 	return structure.Content != nil || len(contentFiles) > 0, nil
 }
 
+const mbrDiskSignatureAddress = 440
+
 func fixDiskIDOnMBR(imgName string) error {
 	var existingDiskIds [][]byte
 	randomBytes, err := generateUniqueDiskID(&existingDiskIds)
@@ -321,7 +323,7 @@ func fixDiskIDOnMBR(imgName string) error {
 			err.Error())
 	}
 	defer diskFile.Close()
-	_, err = diskFile.WriteAt(randomBytes, 440)
+	_, err = diskFile.WriteAt(randomBytes, mbrDiskSignatureAddress)
 	if err != nil {
 		return fmt.Errorf("Error writing MBR disk identifier: %s", err.Error())
 	}

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -321,7 +321,7 @@ func (stateMachine *StateMachine) warnUsageOfSystemLabel(volumeName string, stru
 	}
 }
 
-// handleSystemSeed checks if the struture is a system-seed one and fixes the Label if needed
+// handleSystemSeed checks if the structure is a system-seed one and fixes the Label if needed
 func (stateMachine *StateMachine) handleSystemSeed(volume *gadget.Volume, structure *gadget.VolumeStructure, structIndex int) {
 	if structure.Role != gadget.SystemSeed {
 		return
@@ -548,10 +548,10 @@ func (stateMachine *StateMachine) writeMetadata(metadataFile string) error {
 }
 
 // handleContentSizes ensures that the sizes of the partitions are large enough and stores
-// safe values in the stateMachine struct for use during make_image
+// safe values in the stateMachine struct for use during make_disk
 func (stateMachine *StateMachine) handleContentSizes(farthestOffset quantity.Offset, volumeName string) {
 	// store volume sizes in the stateMachine Struct. These will be used during
-	// the make_image step
+	// the make_disk step
 	calculated := quantity.Size((farthestOffset/quantity.OffsetMiB + 17) * quantity.OffsetMiB)
 	volumeSize, found := stateMachine.ImageSizes[volumeName]
 	if !found {

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -221,8 +221,8 @@ func (stateMachine *StateMachine) handleMultipleImageSizes() error {
 		if err == nil {
 			// argument passed was numeric.
 			if volumeNumber < len(stateMachine.VolumeOrder) {
-				stateName := stateMachine.VolumeOrder[volumeNumber]
-				stateMachine.ImageSizes[stateName] = parsedSize
+				volumeName := stateMachine.VolumeOrder[volumeNumber]
+				stateMachine.ImageSizes[volumeName] = parsedSize
 			} else {
 				return fmt.Errorf("Volume index %d is out of range", volumeNumber)
 			}

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -173,20 +173,6 @@ func (stateMachine *StateMachine) hasSingleImageSizeValue() bool {
 	return !strings.Contains(stateMachine.commonFlags.Size, ":")
 }
 
-// getSuggestedImageSize returns the suggested size for the given volume
-func (stateMachine *StateMachine) getSuggestedImageSize(volumeName string) quantity.Size {
-	var parsedSize quantity.Size
-	if stateMachine.hasSingleImageSizeValue() {
-		// this scenario has just one size for each volume
-		// no need to check error as it has already been done by
-		// the parseImageSizes function
-		parsedSize, _ = quantity.ParseSize(stateMachine.commonFlags.Size) // nolint: errcheck
-	} else {
-		parsedSize = stateMachine.ImageSizes[volumeName]
-	}
-	return parsedSize
-}
-
 // handleSingleImageSize parses as a single value and applies the image size given in
 // the flag --image-size
 func (stateMachine *StateMachine) handleSingleImageSize() error {

--- a/internal/statemachine/testdata/gadget-empty-part.yaml
+++ b/internal/statemachine/testdata/gadget-empty-part.yaml
@@ -20,7 +20,7 @@ volumes:
       - name: EFI System
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 50M
         content:
           - source: grubx64.efi

--- a/internal/statemachine/testdata/gadget-gpt-efi-only.yaml
+++ b/internal/statemachine/testdata/gadget-gpt-efi-only.yaml
@@ -6,7 +6,7 @@ volumes:
       - name: EFI System
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 50M
         content:
           - source: grubx64.efi

--- a/internal/statemachine/testdata/gadget-gpt.yaml
+++ b/internal/statemachine/testdata/gadget-gpt.yaml
@@ -18,7 +18,7 @@ volumes:
       - name: EFI System
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 50M
         content:
           - source: grubx64.efi

--- a/internal/statemachine/testdata/gadget-gpt4k.yaml
+++ b/internal/statemachine/testdata/gadget-gpt4k.yaml
@@ -18,7 +18,7 @@ volumes:
       - name: EFI System
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 512M
         content:
           - source: grubx64.efi

--- a/internal/statemachine/testdata/gadget-hybrid.yaml
+++ b/internal/statemachine/testdata/gadget-hybrid.yaml
@@ -17,7 +17,7 @@ volumes:
       - name: EFI System
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 50M
         content:
           - source: grubx64.efi

--- a/internal/statemachine/testdata/gadget-mbr.yaml
+++ b/internal/statemachine/testdata/gadget-mbr.yaml
@@ -18,7 +18,7 @@ volumes:
       - name: EFI System
         type: EF
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 50M
         content:
           - source: grubx64.efi

--- a/internal/statemachine/testdata/gadget-multi.yaml
+++ b/internal/statemachine/testdata/gadget-multi.yaml
@@ -5,7 +5,7 @@ volumes:
       - name: EFI System
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 50M
         content:
           - source: grubx64.efi
@@ -18,7 +18,6 @@ volumes:
     structure:
         - type: 00000000-0000-0000-0000-0000feedface
           size: 200
-          role: system-boot
   third:
     structure:
         - type: 00000000-0000-0000-0000-0000deafbead

--- a/internal/statemachine/testdata/gadget-no-content.yaml
+++ b/internal/statemachine/testdata/gadget-no-content.yaml
@@ -17,5 +17,5 @@ volumes:
       - name: system-boot
         type: 0C,EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 50M

--- a/internal/statemachine/testdata/gadget_dir/gadget.yaml
+++ b/internal/statemachine/testdata/gadget_dir/gadget.yaml
@@ -17,7 +17,7 @@ volumes:
       - name: EFI System
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 50M
         content:
           - source: grubx64.efi

--- a/internal/statemachine/testdata/gadget_invalid_content.yaml
+++ b/internal/statemachine/testdata/gadget_invalid_content.yaml
@@ -5,7 +5,7 @@ volumes:
     structure:
       - type: 0C
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 512M
         content:
           - source: ../install/boot-assets/

--- a/internal/statemachine/testdata/gadget_tree/meta/gadget.yaml
+++ b/internal/statemachine/testdata/gadget_tree/meta/gadget.yaml
@@ -17,7 +17,7 @@ volumes:
       - name: EFI System
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        filesystem-label: system-boot
+        role: system-boot
         size: 50M
         content:
           - source: grubx64.efi

--- a/internal/statemachine/testdata/image_definitions/test_bad_class.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_bad_class.yaml
@@ -10,6 +10,7 @@ gadget:
   branch: classic
   type: "git"
 rootfs:
+  sources-list-deb822: true
   seed:
     urls:
       - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"

--- a/internal/statemachine/testdata/image_definitions/test_bad_ppa_name.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_bad_ppa_name.yaml
@@ -10,6 +10,7 @@ gadget:
   branch: classic
   type: "git"
 rootfs:
+  sources-list-deb822: true
   components:
     - main
     - universe

--- a/internal/statemachine/testdata/image_definitions/test_bad_url.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_bad_url.yaml
@@ -10,6 +10,7 @@ gadget:
   branch: classic
   type: "git"
 rootfs:
+  sources-list-deb822: true
   seed:
     url: "And this isn't either!"
     branch: jammy

--- a/internal/statemachine/testdata/image_definitions/test_both_seed_and_tasks.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_both_seed_and_tasks.yaml
@@ -10,6 +10,7 @@ gadget:
   branch: classic
   type: "git"
 rootfs:
+  sources-list-deb822: true
   seed:
     urls:
       - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"

--- a/internal/statemachine/testdata/image_definitions/test_git_gadget_without_url.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_git_gadget_without_url.yaml
@@ -9,6 +9,7 @@ gadget:
   branch: classic
   type: "git"
 rootfs:
+  sources-list-deb822: true
   seed:
     urls:
       - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"

--- a/internal/statemachine/testdata/image_definitions/test_image_without_gadget.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_image_without_gadget.yaml
@@ -6,6 +6,7 @@ series: jammy
 class: preinstalled
 kernel: linux-image-generic
 rootfs:
+  sources-list-deb822: true
   components:
     - main
     - universe

--- a/internal/statemachine/testdata/image_definitions/test_invalid_model_assertion_url.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_model_assertion_url.yaml
@@ -11,6 +11,7 @@ gadget:
   branch: "classic-redesign"
   type: "git"
 rootfs:
+  sources-list-deb822: true
   seed:
     urls:
       - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"

--- a/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_copy.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_copy.yaml
@@ -10,6 +10,7 @@ gadget:
   branch: "classic"
   type: "git"
 rootfs:
+  sources-list-deb822: true
   archive: ubuntu
   mirror: "http://ports.ubuntu.com/ubuntu/"
   seed:

--- a/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_mkdir.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_mkdir.yaml
@@ -10,6 +10,7 @@ gadget:
   branch: "classic"
   type: "git"
 rootfs:
+  sources-list-deb822: true
   archive: ubuntu
   mirror: "http://ports.ubuntu.com/ubuntu/"
   seed:

--- a/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_touch_file.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_invalid_paths_in_manual_touch_file.yaml
@@ -10,6 +10,7 @@ gadget:
   branch: "classic"
   type: "git"
 rootfs:
+  sources-list-deb822: true
   archive: ubuntu
   mirror: "http://ports.ubuntu.com/ubuntu/"
   seed:

--- a/internal/statemachine/testdata/image_definitions/test_missing_name.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_missing_name.yaml
@@ -9,6 +9,7 @@ gadget:
   branch: classic
   type: "git"
 rootfs:
+  sources-list-deb822: true
   seed:
     urls:
       - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"

--- a/internal/statemachine/testdata/image_definitions/test_prebuilt_gadget.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_prebuilt_gadget.yaml
@@ -9,6 +9,7 @@ gadget:
   url: "file://test.tar"
   type: "directory"
 rootfs:
+  sources-list-deb822: true
   seed:
     urls:
       - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"

--- a/internal/statemachine/testdata/image_definitions/test_private_ppa_without_fingerprint.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_private_ppa_without_fingerprint.yaml
@@ -10,6 +10,7 @@ gadget:
   branch: classic
   type: "git"
 rootfs:
+  sources-list-deb822: true
   seed:
     urls:
       - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"

--- a/internal/statemachine/testdata/image_definitions/test_qcow2.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_qcow2.yaml
@@ -10,6 +10,7 @@ gadget:
   branch: classic
   type: "git"
 rootfs:
+  sources-list-deb822: true
   components:
     - main
     - universe

--- a/internal/statemachine/testdata/image_definitions/test_raspi.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_raspi.yaml
@@ -11,6 +11,7 @@ gadget:
   type: "git"
 model-assertion: file://pi-generic.model
 rootfs:
+  sources-list-deb822: true
   archive: ubuntu
   components:
     - main

--- a/internal/statemachine/testdata/image_definitions/test_rootfs_seed.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_rootfs_seed.yaml
@@ -11,6 +11,7 @@ gadget:
   type: "git"
 rootfs:
   seed:
+    sources-list-deb822: true
     urls:
       - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
     branch: jammy

--- a/internal/statemachine/testdata/image_definitions/test_rootfs_tarball.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_rootfs_tarball.yaml
@@ -10,6 +10,7 @@ gadget:
   branch: classic
   type: "git"
 rootfs:
+  sources-list-deb822: true
   components:
     - main
     - universe


### PR DESCRIPTION
Some refactoring (specifically of `createDiskImage()`), typos and small changes on the test dataset to get rid of some warning in tests. 