### PR TITLE
Fix YAML validation to enable having no gadget and no artifact at the same time

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,8 @@ ubuntu-image (3.5) UNRELEASED; urgency=medium
   * Improve validation and overall handling of volumes from the
     gadget.yaml. 
   * Migrate to core24 and bump minimum series to build to 20.04
+  * Make sure an image definition without gadget nor artifacts
+    section is valid.
 
   [ Maciej Borzecki ]
   * Improve handling of structures without a filesystem.

--- a/internal/statemachine/classic.go
+++ b/internal/statemachine/classic.go
@@ -185,7 +185,7 @@ func validateImageDefinition(imageDefinition *imagedefinition.ImageDefinition) e
 	return nil
 }
 
-// validateCustomization validates the Gadget section of the image definition
+// validateGadget validates the Gadget section of the image definition
 func validateGadget(imageDefinition *imagedefinition.ImageDefinition, result *gojsonschema.Result) error {
 	// Do custom validation for gadgetURL being required if gadget is not pre-built
 	if imageDefinition.Gadget != nil {
@@ -204,7 +204,7 @@ func validateGadget(imageDefinition *imagedefinition.ImageDefinition, result *go
 				errDetail,
 			)
 		}
-	} else {
+	} else if imageDefinition.Artifacts != nil {
 		diskUsed, err := helperCheckTags(imageDefinition.Artifacts, "is_disk")
 		if err != nil {
 			return fmt.Errorf("Error checking struct tags for Artifacts: \"%s\"", err.Error())

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -68,6 +68,7 @@ func TestYAMLSchemaParsing(t *testing.T) {
 		expectedError   string
 	}{
 		{"valid_image_definition", "test_raspi.yaml", true, ""},
+		{"valid_image_definition_no_gadget_no_artifact", "test_image_without_gadget_artifact.yaml", true, ""},
 		{"invalid_class", "test_bad_class.yaml", false, "Class must be one of the following"},
 		{"invalid_url", "test_bad_url.yaml", false, "Does not match format 'uri'"},
 		{"invalid_model_assertion_url", "test_invalid_model_assertion_url.yaml", false, "Does not match format 'uri'"},

--- a/internal/statemachine/testdata/image_definitions/test_image_without_gadget_artifact.yaml
+++ b/internal/statemachine/testdata/image_definitions/test_image_without_gadget_artifact.yaml
@@ -1,0 +1,50 @@
+name: ubuntu-server-amd64
+display-name: Ubuntu Server amd64
+revision: 1
+architecture: amd64
+series: jammy
+class: preinstalled
+kernel: linux-image-generic
+rootfs:
+  sources-list-deb822: true
+  components:
+    - main
+    - universe
+    - restricted
+  seed:
+    urls:
+      - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
+      - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
+    branch: jammy
+    names:
+      - server
+      - minimal
+      - standard
+      - cloud-image
+customization:
+  cloud-init:
+    user-data: |
+      #cloud-config
+      chpasswd:
+        expire: true
+        users:
+          - name: ubuntu
+            password: ubuntu
+            type: text
+  extra-snaps:
+    -
+      name: hello
+      channel: candidate
+  extra-ppas:
+    -
+      name: "canonical-foundations/ubuntu-image"
+      fingerprint: "CDE5112BD4104F975FC8A53FD4C0B668FD4C9139"
+    -
+      name: "canonical-foundations/ubuntu-image-private-test"
+      auth: "sil2100:vVg74j6SM8WVltwpxDRJ"
+      fingerprint: "CDE5112BD4104F975FC8A53FD4C0B668FD4C9139"
+  extra-packages:
+    -
+      name: "hello-ubuntu-image-public"
+    -
+      name: "hello-ubuntu-image-private"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.4+snap7"
+version: "3.4+snap8"
 grade: stable
 confinement: classic
 base: core24


### PR DESCRIPTION
Previously the gadget section validation worked under the assumption the artifacts section was defined. We are not enforcing that.

This bug was spotted while debugging imagecraft because it creates a minimal image definition, without gadget nor artifacts sections.