### PR TITLE
Use cp instead of mv to install configs to correct directory

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -63,7 +63,7 @@ parts:
       git config --global --add safe.directory $CRAFT_PROJECT_DIR/.git
       craftctl default
     override-build: |
-      mv mkfs "$SNAPCRAFT_PART_INSTALL"/etc/ubuntu-image/
+      cp -r mkfs "$SNAPCRAFT_PART_INSTALL"/etc/ubuntu-image/
       ins_bin=$SNAPCRAFT_PART_INSTALL/bin/
       mkdir -p "$ins_bin"
       # Make ubuntu-image statically compiled to avoid libc deps.


### PR DESCRIPTION
With mv the configs for some reason end up in `/snap/ubuntu-image/current/etc/ubuntu-image/confs/` instead of the expected `/snap/ubuntu-image/current/etc/ubuntu-image/mkfs/confs/`. Using `cp -r` does the right thing.