### PR TITLE
snapcraft.yaml: Fix config installation

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -63,7 +63,8 @@ parts:
       git config --global --add safe.directory $CRAFT_PROJECT_DIR/.git
       craftctl default
     override-build: |
-      mv mkfs "$SNAPCRAFT_PART_INSTALL"/etc/ubuntu-image/
+      mkdir -p "$SNAPCRAFT_PART_INSTALL"/etc/ubuntu-image/
+      mv mkfs/confs "$SNAPCRAFT_PART_INSTALL"/etc/ubuntu-image/mkfs
       ins_bin=$SNAPCRAFT_PART_INSTALL/bin/
       mkdir -p "$ins_bin"
       # Make ubuntu-image statically compiled to avoid libc deps.


### PR DESCRIPTION
u-i expects mkfs configs in /etc/ubuntu-image/mkfs/$SERIES/mke2fs.conf, this makes sure they get installed to the correct directory

The lookup path is constructed in https://github.com/canonical/ubuntu-image/blob/main/internal/statemachine/helper.go#L296 as `strings.Join([]string{osGetenv("SNAP"), MKE2FS_BASE_PATH, series, MKE2FS_CONFIG_FILE}, "/")` which expands to `/etc/ubuntu-image/mkfs/$series/mke2fs.conf`.

Previously the configs were installed in `/etc/ubuntu-image/confs/$series/mke2fs.conf` instead and consequently ignored.