### PR TITLE
Add dosfstools

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -13,6 +13,7 @@ ubuntu-image (3.5) UNRELEASED; urgency=medium
   * Test running ubuntu-image on noble
   * Make sure the mkfs conf is copied at the right place when building
     the snap.
+  * Add dosfstools to the snap.
 
   [ Maciej Borzecki ]
   * Improve handling of structures without a filesystem.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -35,6 +35,7 @@ parts:
     stage-packages:
       - binfmt-support
       - dirmngr
+      - dosfstools
       - fdisk
       - gdisk
       - fakeroot

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.4+snap11"
+version: "3.4+snap12"
 grade: stable
 confinement: classic
 base: core24


### PR DESCRIPTION
mkfs.vfat is missing in the snap. It was spotted while trying to build an image with imagecraft on a basic 24.04 VM.