### PR TITLE
Clean /dev/, /run/, /sys/

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -14,6 +14,7 @@ ubuntu-image (3.5) UNRELEASED; urgency=medium
   * Make sure the mkfs conf is copied at the right place when building
     the snap.
   * Add dosfstools to the snap.
+  * Clean /dev/ to avoid issues when booting or moving the chroot around
 
   [ Maciej Borzecki ]
   * Improve handling of structures without a filesystem.

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -1351,6 +1351,7 @@ func (stateMachine *StateMachine) cleanRootfs() error {
 			filepath.Join("etc", "ssh", "ssh_host_*_key"),
 			filepath.Join("var", "cache", "debconf", "*-old"),
 			filepath.Join("var", "lib", "dpkg", "*-old"),
+			filepath.Join("dev", "*"),
 		})
 	if err != nil {
 		return err

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -1352,6 +1352,8 @@ func (stateMachine *StateMachine) cleanRootfs() error {
 			filepath.Join("var", "cache", "debconf", "*-old"),
 			filepath.Join("var", "lib", "dpkg", "*-old"),
 			filepath.Join("dev", "*"),
+			filepath.Join("sys", "*"),
+			filepath.Join("run", "*"),
 		})
 	if err != nil {
 		return err
@@ -1394,7 +1396,7 @@ func listWithPatterns(chroot string, patterns []string) ([]string, error) {
 // doDeleteFiles deletes the given list of files
 func doDeleteFiles(toDelete []string) error {
 	for _, f := range toDelete {
-		err := osRemove(f)
+		err := osRemoveAll(f)
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("Error removing %s: %s", f, err.Error())
 		}

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -5354,6 +5354,10 @@ func TestClassicStateMachine_cleanRootfs_real_rootfs(t *testing.T) {
 		filepath.Join(stateMachine.tempDirs.chroot, "etc", "ssh", "ssh_host_rsa_key.pub"),
 		filepath.Join(stateMachine.tempDirs.chroot, "etc", "ssh", "ssh_host_ecdsa_key"),
 		filepath.Join(stateMachine.tempDirs.chroot, "etc", "ssh", "ssh_host_ecdsa_key.pub"),
+		filepath.Join(stateMachine.tempDirs.chroot, "dev", "stderr"),
+		filepath.Join(stateMachine.tempDirs.chroot, "dev", "stdin"),
+		filepath.Join(stateMachine.tempDirs.chroot, "dev", "stdout"),
+		filepath.Join(stateMachine.tempDirs.chroot, "dev", "fd"),
 	}
 	for _, file := range cleaned {
 		_, err := os.Stat(file)
@@ -5397,6 +5401,9 @@ func TestClassicStateMachine_cleanRootfs(t *testing.T) {
 				filepath.Join("etc", "udev", "rules.d", "test2-persistent-net.rules"),
 				filepath.Join("var", "cache", "debconf", "test-old"),
 				filepath.Join("var", "lib", "dpkg", "testdpkg-old"),
+				filepath.Join("dev", "stderr"),
+				filepath.Join("dev", "stdin"),
+				filepath.Join("dev", "stdout"),
 			},
 			wantRootfsContent: map[string]int64{
 				filepath.Join("etc", "machine-id"):                                    0,
@@ -5421,6 +5428,9 @@ func TestClassicStateMachine_cleanRootfs(t *testing.T) {
 				filepath.Join("etc", "udev", "rules.d", "test-persistent-net.rules"),
 				filepath.Join("var", "cache", "debconf", "test-old"),
 				filepath.Join("var", "lib", "dpkg", "testdpkg-old"),
+				filepath.Join("dev", "stderr"),
+				filepath.Join("dev", "stdin"),
+				filepath.Join("dev", "stdout"),
 			},
 			wantRootfsContent: map[string]int64{
 				filepath.Join("etc", "machine-id"):                                   sampleSize,
@@ -5428,6 +5438,9 @@ func TestClassicStateMachine_cleanRootfs(t *testing.T) {
 				filepath.Join("etc", "udev", "rules.d", "test-persistent-net.rules"): sampleSize,
 				filepath.Join("var", "cache", "debconf", "test-old"):                 sampleSize,
 				filepath.Join("var", "lib", "dpkg", "testdpkg-old"):                  sampleSize,
+				filepath.Join("dev", "stderr"):                                       sampleSize,
+				filepath.Join("dev", "stdin"):                                        sampleSize,
+				filepath.Join("dev", "stdout"):                                       sampleSize,
 			},
 		},
 		{

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -5358,6 +5358,10 @@ func TestClassicStateMachine_cleanRootfs_real_rootfs(t *testing.T) {
 		filepath.Join(stateMachine.tempDirs.chroot, "dev", "stdin"),
 		filepath.Join(stateMachine.tempDirs.chroot, "dev", "stdout"),
 		filepath.Join(stateMachine.tempDirs.chroot, "dev", "fd"),
+		filepath.Join(stateMachine.tempDirs.chroot, "sys", "kernel", "security"),
+		filepath.Join(stateMachine.tempDirs.chroot, "sys", "fs", "cgroup"),
+		filepath.Join(stateMachine.tempDirs.chroot, "run", "mount", "utab.lock"),
+		filepath.Join(stateMachine.tempDirs.chroot, "run", "lock"),
 	}
 	for _, file := range cleaned {
 		_, err := os.Stat(file)
@@ -5404,6 +5408,8 @@ func TestClassicStateMachine_cleanRootfs(t *testing.T) {
 				filepath.Join("dev", "stderr"),
 				filepath.Join("dev", "stdin"),
 				filepath.Join("dev", "stdout"),
+				filepath.Join("sys", "kernel", "security"),
+				filepath.Join("run", "mount", "utab.lock"),
 			},
 			wantRootfsContent: map[string]int64{
 				filepath.Join("etc", "machine-id"):                                    0,
@@ -5418,8 +5424,8 @@ func TestClassicStateMachine_cleanRootfs(t *testing.T) {
 					&testhelper.OSMockConf{},
 				)
 
-				osRemove = mock.Remove
-				return func() { osRemove = os.Remove }
+				osRemoveAll = mock.RemoveAll
+				return func() { osRemoveAll = os.RemoveAll }
 			},
 			expectedErr: "Error removing",
 			initialRootfsContent: []string{
@@ -5431,6 +5437,8 @@ func TestClassicStateMachine_cleanRootfs(t *testing.T) {
 				filepath.Join("dev", "stderr"),
 				filepath.Join("dev", "stdin"),
 				filepath.Join("dev", "stdout"),
+				filepath.Join("sys", "kernel", "security"),
+				filepath.Join("run", "mount", "utab.lock"),
 			},
 			wantRootfsContent: map[string]int64{
 				filepath.Join("etc", "machine-id"):                                   sampleSize,
@@ -5441,6 +5449,8 @@ func TestClassicStateMachine_cleanRootfs(t *testing.T) {
 				filepath.Join("dev", "stderr"):                                       sampleSize,
 				filepath.Join("dev", "stdin"):                                        sampleSize,
 				filepath.Join("dev", "stdout"):                                       sampleSize,
+				filepath.Join("sys", "kernel", "security"):                           sampleSize,
+				filepath.Join("run", "mount", "utab.lock"):                           sampleSize,
 			},
 		},
 		{

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -26,6 +26,7 @@ type OSMockConf struct {
 	OsutilCopySpecialFileThreshold uint
 	ReadDirThreshold               uint
 	RemoveThreshold                uint
+	RemoveAllThreshold             uint
 	TruncateThreshold              uint
 	OpenFileThreshold              uint
 	MkdirAllThreshold              uint
@@ -42,6 +43,7 @@ type osMock struct {
 	beforeOsutilCopySpecialFileFail uint
 	beforeReadDirFail               uint
 	beforeRemoveFail                uint
+	beforeRemoveAllFail             uint
 	beforeTruncateFail              uint
 	beforeOpenFileFail              uint
 	beforeMkdirAllFail              uint
@@ -75,6 +77,15 @@ func (o *osMock) Remove(name string) error {
 		return fmt.Errorf("Remove fail")
 	}
 	o.beforeRemoveFail++
+
+	return nil
+}
+
+func (o *osMock) RemoveAll(name string) error {
+	if o.beforeRemoveAllFail >= o.conf.RemoveAllThreshold {
+		return fmt.Errorf("RemoveAll fail")
+	}
+	o.beforeRemoveAllFail++
 
 	return nil
 }

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.4+snap12"
+version: "3.4+snap13"
 grade: stable
 confinement: classic
 base: core24


### PR DESCRIPTION
Some files (links, character devices, etc.) were left over in the `/dev/` and were causing issues when booting or when the resulting chroot was moved around by Imagecraft (refusing to move named pipes). Also clean `/run/`and `/sys/`.

