### PR TITLE
lint: Fix golangci-lint error

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -24,6 +24,9 @@ linters-settings:
     max-func-lines: 5
   errcheck:
     check-blank: true
+  gosec:
+    excludes:
+      - G115 # should be removed as soon as this rule works properly
 issues:
   # these values ensure that all issues will be surfaced
   max-issues-per-linter: 0

--- a/.github/workflows/go-quality-checks.yml
+++ b/.github/workflows/go-quality-checks.yml
@@ -21,7 +21,7 @@ jobs:
         run: FMT=`go fmt ./...` && [ -z "$FMT" ]
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         id: lint
         with:
           version: latest

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -3,6 +3,7 @@ package statemachine
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io/fs"
 	"math"
@@ -723,7 +724,7 @@ func execTeardownCmds(teardownCmds []*exec.Cmd, debug bool, prevErr error) (err 
 		err = fmt.Errorf("teardown failed: %s", strings.Join(errs, "\n"))
 		if prevErr != nil {
 			errs := append([]string{prevErr.Error()}, errs...)
-			err = fmt.Errorf(strings.Join(errs, "\n"))
+			err = errors.New(strings.Join(errs, "\n"))
 		}
 	}
 


### PR DESCRIPTION
This is due to the new version incorporating new go1.23 vet behavior.