### PR TITLE
Fix UC image size

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -15,6 +15,8 @@ ubuntu-image (3.5) UNRELEASED; urgency=medium
     the snap.
   * Add dosfstools to the snap.
   * Clean /dev/ to avoid issues when booting or moving the chroot around
+  * Use the proper size from the volume to determine the minimum image
+    size.
 
   [ Maciej Borzecki ]
   * Improve handling of structures without a filesystem.

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 
 require (
 	github.com/snapcore/secboot v0.0.0-20240411101434-f3ad7c92552a // indirect
-	github.com/snapcore/snapd v0.0.0-20240911193218-25e66bfc4669
+	github.com/snapcore/snapd v0.0.0-20241010070736-df476d41dcaa
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/snapcore/secboot v0.0.0-20240411101434-f3ad7c92552a/go.mod h1:72paVOk
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
 github.com/snapcore/snapd v0.0.0-20240911193218-25e66bfc4669 h1:h5cydUNPhp4gaT05zVgrT4yjXCGW2ev+mXRfKU2xB7Q=
 github.com/snapcore/snapd v0.0.0-20240911193218-25e66bfc4669/go.mod h1:RfaJNlcyEP2RfVuyAX/3x+CJPECCAlZn+36Yily9FzY=
+github.com/snapcore/snapd v0.0.0-20241010070736-df476d41dcaa h1:jsoJaQ+a8iFYMoF3K5S6FsjaUWJPWyD9eYIDWQS2CuA=
+github.com/snapcore/snapd v0.0.0-20241010070736-df476d41dcaa/go.mod h1:c9j4npxTEGjMy6E/7ocAazCMR+82ZWTh/o+5Ic7ilPc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/helper/structure.go
+++ b/internal/helper/structure.go
@@ -40,12 +40,9 @@ func IsSystemSeedStructure(s *gadget.VolumeStructure) bool {
 
 // ShouldSkipStructure returns whether a structure should be skipped during certain processing
 func ShouldSkipStructure(structure *gadget.VolumeStructure, isSeeded bool) bool {
-	if isSeeded &&
+	return isSeeded &&
 		(structure.Role == gadget.SystemBoot ||
 			structure.Label == gadget.SystemBoot ||
 			structure.Role == gadget.SystemData ||
-			structure.Role == gadget.SystemSave) {
-		return true
-	}
-	return false
+			structure.Role == gadget.SystemSave)
 }

--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -448,26 +448,11 @@ func (stateMachine *StateMachine) makeDisk() error {
 	return nil
 }
 
-// VolumeMaxSize get the max size of a volume from its structures
-// TODO remove once https://github.com/canonical/snapd/pull/14561 is merged
-func VolumeMaxSize(v *gadget.Volume) quantity.Size {
-	endVol := quantity.Offset(0)
-	for _, s := range v.Structure {
-		if s.Offset != nil {
-			endVol = *s.Offset + quantity.Offset(s.Size)
-		} else {
-			endVol += quantity.Offset(s.Size)
-		}
-	}
-
-	return quantity.Size(endVol)
-}
-
 // createDiskImage creates a disk image and makes sure the size respects the configuration and
 // the SectorSize
 func (stateMachine *StateMachine) createDiskImage(volumeName string, volume *gadget.Volume, imgName string) (*diskutils.Disk, error) {
 	// Calculate the minimum size that would be needed according to gadget.yaml.
-	imgSize := VolumeMaxSize(volume)
+	imgSize := volume.Size()
 
 	desiredImgSize, found := stateMachine.ImageSizes[volumeName]
 	if found && desiredImgSize > imgSize {

--- a/internal/statemachine/common_states.go
+++ b/internal/statemachine/common_states.go
@@ -177,7 +177,7 @@ func (stateMachine *StateMachine) calculateRootfsSize() error {
 	}
 
 	if rootfsStructure != nil {
-		setStructureSize(rootfsStructure, stateMachine.RootfsSize)
+		raiseStructureSizes(rootfsStructure, stateMachine.RootfsSize)
 	}
 
 	return nil

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -407,11 +407,15 @@ func maxOffset(offset1, offset2 quantity.Offset) quantity.Offset {
 	return offset2
 }
 
-// setStructureSize sets both Size and MinSize to the same value on a structure
+// setStructureSize raise both Size and MinSize to at least the given size
 // It helps make sure whatever value is used in snapd, it is set to the size we need
 func setStructureSize(s *gadget.VolumeStructure, size quantity.Size) {
-	s.MinSize = size
-	s.Size = size
+	if s.MinSize < size {
+		s.MinSize = size
+	}
+	if s.Size < size {
+		s.Size = size
+	}
 }
 
 // copyDataToImage runs dd commands to copy the raw data to the final image with appropriate offsets

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -407,9 +407,9 @@ func maxOffset(offset1, offset2 quantity.Offset) quantity.Offset {
 	return offset2
 }
 
-// setStructureSize raise both Size and MinSize to at least the given size
+// raiseStructureSizes raise both Size and MinSize to at least the given size
 // It helps make sure whatever value is used in snapd, it is set to the size we need
-func setStructureSize(s *gadget.VolumeStructure, size quantity.Size) {
+func raiseStructureSizes(s *gadget.VolumeStructure, size quantity.Size) {
 	if s.MinSize < size {
 		s.MinSize = size
 	}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.4+snap13"
+version: "3.4+snap14"
 grade: stable
 confinement: classic
 base: core24


### PR DESCRIPTION
Since the Go rewrite we were adding 34*1024 sectors of 512 bytes at the end of the disk to account for the GPT backup header. This was too much and was hiding the fact that we were not calculating the size needed by the structures defined in the gadget.yaml.

Now that the partition handling has been reworked, some room was missing. 

Fix the issue by using the max volume size as the minimum size needed.

Solves LP: #2077572.
Closes: FR-9159

