### PR TITLE
internal/commands, internal/statemachine: allow forwarding components to "snap prepare-image"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-image (3.6.0) UNRELEASED; urgency=medium
+
+  [ Andrew Phelps ]
+  * Add support for builing core images with components
+
+ -- Andrew Phelps <andrew.phelps@canonical.com>  Mon, 25 Nov 2024 10:30:04 -0500
+
 ubuntu-image (3.5.1) UNRELEASED; urgency=medium
 
   [ Paul Mars ]

--- a/internal/commands/snap.go
+++ b/internal/commands/snap.go
@@ -13,6 +13,7 @@ type SnapOpts struct {
 	AppArmorKernelFeaturesDir string         `long:"apparmor-features-dir" description:"Optional path to apparmor kernel features directory"`
 	PreseedSignKey            string         `long:"preseed-sign-key" description:"Name of the key to use to sign preseed assertion, otherwise use the default key"`
 	Snaps                     []string       `long:"snap" description:"Install extra snaps. These are passed through to \"snap prepare-image\". The snap argument can include additional information about the channel and/or risk with the following syntax: <snap>=<channel|risk>" value-name:"SNAP"`
+	Components                []string       `long:"comp" description:"Install extra components. These are passed through to \"snap prepare-image\"." value-name:"COMPONENT"`
 	CloudInit                 string         `long:"cloud-init" description:"cloud-config data to be copied to the image" value-name:"USER-DATA-FILE"`
 	Revisions                 map[string]int `long:"revision" description:"The revision of a specific snap to install in the image." value-name:"REVISION"`
 	SysfsOverlay              string         `long:"sysfs-overlay" description:"The optional sysfs overlay to used for preseeding. Directories from /sys/class/* and /sys/devices/platform will be bind-mounted to the chroot when preseeding"`

--- a/internal/statemachine/snap_states.go
+++ b/internal/statemachine/snap_states.go
@@ -28,6 +28,7 @@ func (stateMachine *StateMachine) prepareImage() error {
 		PrepareDir:                snapStateMachine.tempDirs.unpack,
 		Channel:                   snapStateMachine.commonFlags.Channel,
 		Customizations:            snapStateMachine.imageOptsCustomizations(),
+		Components:                snapStateMachine.Opts.Components,
 	}
 
 	var err error

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.5.1"
+version: "3.6.0"
 grade: stable
 confinement: classic
 base: core24


### PR DESCRIPTION
Needs some tests, but I think this should be what we need.