### PR TITLE
Fix build components with legacy sources.list

### DIFF
--- a/internal/imagedefinition/image_definition.go
+++ b/internal/imagedefinition/image_definition.go
@@ -372,13 +372,15 @@ func (i *ImageDefinition) LegacyTargetSourcesList() string {
 // legacy format (not deb822).
 func (i *ImageDefinition) legacySourcesList(target bool) string {
 	pocket := i.Rootfs.Pocket
+	components := i.Rootfs.Components
 	if target {
 		pocket = i.Customization.Pocket
+		components = i.Customization.Components
 	}
 
 	return generateLegacySourcesList(
 		i.Series,
-		i.Customization.Components,
+		components,
 		i.Rootfs.Mirror,
 		i.securityMirror(),
 		strings.ToLower(pocket))


### PR DESCRIPTION
During build, the Rootfs definitions should be used for APT sources, while the Customization definitions should be used in the final image. For the legacy APT sources generation, we only followed this logic for the pocket value, not for components.

This might also make sense for mirror, but that's not a standalone Customization option.