### PR TITLE
Check if the copy file source is absolute

### DIFF
--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -753,7 +753,10 @@ func manualMakeDirs(customizations []*imagedefinition.MakeDirs, targetDir string
 // manualCopyFile copies a file into the chroot
 func manualCopyFile(customizations []*imagedefinition.CopyFile, confDefPath string, targetDir string, debug bool) error {
 	for _, c := range customizations {
-		source := filepath.Join(confDefPath, c.Source)
+		source := c.Source
+		if !filepath.IsAbs(source) {
+			source = filepath.Join(confDefPath, source)
+		}
 		dest := filepath.Join(targetDir, c.Dest)
 		if debug {
 			fmt.Printf("Copying file \"%s\" to \"%s\"\n", source, dest)


### PR DESCRIPTION
From the mm discussion
https://github.com/canonical/ubuntu-image/blob/main/internal/imagedefinition/README.rst
```
    copy-file: (optional)
      -
        # The path to the file to copy.
        # The given path will be interpreted as relative to the
        # path of the image definition file if is not absolute.
        source: <string>
```

mentions
>  if is not absolute

but the code actually never checks that the path is absolute or not and always use it relative
from : https://github.com/canonical/ubuntu-image/blob/4842e19426cc50f39d7b91c1f394b852dcd6f8a4/internal/statemachine/helper.go#L756-L758

Simple PR that fixes this.