### PR TITLE
i/statemachine: add manifest-v2 to align with livecd-rootfs format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-image (3.10.9) UNRELEASED; urgency=medium
+
+  * Add manifest-v2 artifacts to generate a livecd-rootfs formatted manifest
+
+ -- Alexis Cellier <alexis.cellier@canonical.com>  Mon, 01 Jun 2026 23:25:20 +0000
+
 ubuntu-image (3.10.8) UNRELEASED; urgency=medium
 
   * Add support for gadgets defining a system-boot-state partition

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -109,7 +109,7 @@ func CopyBlob(ddArgs []string) error {
 // bools are supported
 func SetDefaults(needsDefaults interface{}) error {
 	value := reflect.ValueOf(needsDefaults)
-	if value.Kind() != reflect.Ptr {
+	if value.Kind() != reflect.Pointer {
 		return fmt.Errorf("The argument to SetDefaults must be a pointer")
 	}
 	elem := value.Elem()
@@ -122,7 +122,7 @@ func SetDefaults(needsDefaults interface{}) error {
 			if err != nil {
 				return err
 			}
-		} else if field.Type().Kind() == reflect.Ptr {
+		} else if field.Type().Kind() == reflect.Pointer {
 			err := setDefaultToPtr(field, elem, i)
 			if err != nil {
 				return err
@@ -217,7 +217,7 @@ func setDefaultToBasicType(field reflect.Value, elem reflect.Value, fieldIndex i
 // if it gets merged this can be deleted
 func CheckEmptyFields(Interface interface{}, result *gojsonschema.Result, schema *jsonschema.Schema) error {
 	value := reflect.ValueOf(Interface)
-	if value.Kind() != reflect.Ptr {
+	if value.Kind() != reflect.Pointer {
 		return fmt.Errorf("The argument to CheckEmptyFields must be a pointer")
 	}
 	elem := value.Elem()
@@ -231,7 +231,7 @@ func CheckEmptyFields(Interface interface{}, result *gojsonschema.Result, schema
 			if err != nil {
 				return err
 			}
-		} else if field.Type().Kind() == reflect.Ptr {
+		} else if field.Type().Kind() == reflect.Pointer {
 			// otherwise if it's just a pointer to a nested struct
 			// search it for empty required fields
 			err := checkEmptyFieldsInPtr(field, result, schema)
@@ -268,7 +268,7 @@ func CheckEmptyFields(Interface interface{}, result *gojsonschema.Result, schema
 func checkEmptyFieldsInSlice(field reflect.Value, result *gojsonschema.Result, schema *jsonschema.Schema) error {
 	for i := 0; i < field.Cap(); i++ {
 		sliceElem := field.Index(i)
-		if sliceElem.Kind() == reflect.Ptr && sliceElem.Elem().Kind() == reflect.Struct {
+		if sliceElem.Kind() == reflect.Pointer && sliceElem.Elem().Kind() == reflect.Struct {
 			err := CheckEmptyFields(sliceElem.Interface(), result, schema)
 			if err != nil {
 				return err
@@ -463,7 +463,7 @@ func CalculateSHA256(fileName string) (string, error) {
 // are supported
 func CheckTags(searchStruct interface{}, tag string) (string, error) {
 	value := reflect.ValueOf(searchStruct)
-	if value.Kind() != reflect.Ptr {
+	if value.Kind() != reflect.Pointer {
 		return "", fmt.Errorf("The argument to CheckTags must be a pointer")
 	}
 	elem := value.Elem()

--- a/internal/imagedefinition/README.rst
+++ b/internal/imagedefinition/README.rst
@@ -323,6 +323,12 @@ The following specification defines what is supported in the YAML:
       manifest:
         # Name to output the manifest file.
         name: <string>
+      # A manifest-v2 file is a list of all packages and snaps with their
+      # version numbers (and channel for snaps) that are included in the
+      # rootfs of the image. It has the same format as the livecd-rootfs one.
+      manifest-v2:
+        # Name to output the manifest-v2 file.
+        name: <string>
       # A filelist is a list of all files in the rootfs of the image.
       filelist:
         # Name to output the filelist file.

--- a/internal/imagedefinition/image_definition.go
+++ b/internal/imagedefinition/image_definition.go
@@ -175,12 +175,13 @@ type AddUser struct {
 // Artifact contains information about the files that are created
 // during and as a result of the image build process
 type Artifact struct {
-	Img       *[]Img     `yaml:"img"            json:"Img,omitempty"       is_disk:"true"`
-	Qcow2     *[]Qcow2   `yaml:"qcow2"          json:"Qcow2,omitempty"     is_disk:"true"`
-	Manifest  *Manifest  `yaml:"manifest"       json:"Manifest,omitempty"  is_disk:"false"`
-	Filelist  *Filelist  `yaml:"filelist"       json:"Filelist,omitempty"  is_disk:"false"`
-	Changelog *Changelog `yaml:"changelog"      json:"Changelog,omitempty" is_disk:"false"`
-	RootfsTar *RootfsTar `yaml:"rootfs-tarball" json:"RootfsTar,omitempty" is_disk:"false"`
+	Img        *[]Img     `yaml:"img"            json:"Img,omitempty"       is_disk:"true"`
+	Qcow2      *[]Qcow2   `yaml:"qcow2"          json:"Qcow2,omitempty"     is_disk:"true"`
+	Manifest   *Manifest  `yaml:"manifest"       json:"Manifest,omitempty"    is_disk:"false"`
+	ManifestV2 *Manifest  `yaml:"manifest-v2"    json:"ManifestV2,omitempty"  is_disk:"false"`
+	Filelist   *Filelist  `yaml:"filelist"       json:"Filelist,omitempty"    is_disk:"false"`
+	Changelog  *Changelog `yaml:"changelog"      json:"Changelog,omitempty" is_disk:"false"`
+	RootfsTar  *RootfsTar `yaml:"rootfs-tarball" json:"RootfsTar,omitempty" is_disk:"false"`
 }
 
 // Img specifies the name of the resulting .img file.

--- a/internal/statemachine/classic.go
+++ b/internal/statemachine/classic.go
@@ -530,7 +530,7 @@ func (stateMachine *StateMachine) addArtifactsStates(c *ClassicStateMachine, sta
 		stateMachine.addQcow2States(states)
 	}
 
-	if c.ImageDef.Artifacts.Manifest != nil {
+	if c.ImageDef.Artifacts.Manifest != nil || c.ImageDef.Artifacts.ManifestV2 != nil {
 		*states = append(*states, generatePackageManifestState)
 	}
 

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -1253,29 +1253,9 @@ var generatePackageManifestState = stateFunc{"generate_package_manifest", (*Stat
 func (stateMachine *StateMachine) generatePackageManifest() error {
 	classicStateMachine := stateMachine.parent.(*ClassicStateMachine)
 
-	// This is basically just a wrapper around dpkg-query
 	outputPath := filepath.Join(stateMachine.commonFlags.OutputDir,
 		classicStateMachine.ImageDef.Artifacts.Manifest.ManifestName)
-	cmd := execCommand("chroot", stateMachine.tempDirs.rootfs, "dpkg-query", "-W", "--showformat=${Package} ${Version}\n")
-	cmdOutput := helper.SetCommandOutput(cmd, classicStateMachine.commonFlags.Debug)
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("Error generating package manifest with command \"%s\". "+
-			"Error is \"%s\". Full output below:\n%s",
-			cmd.String(), err.Error(), cmdOutput.String())
-	}
-
-	// write the output to a file on successful executions
-	manifest, err := osCreate(outputPath)
-	if err != nil {
-		return fmt.Errorf("Error creating manifest file: %s", err.Error())
-	}
-	defer manifest.Close()
-	_, err = manifest.Write(cmdOutput.Bytes())
-	if err != nil {
-		return fmt.Errorf("error writing the manifest file: %w", err)
-	}
-	return nil
+	return generateClassicManifest(stateMachine.tempDirs.rootfs, outputPath, classicStateMachine.commonFlags.Debug)
 }
 
 var generateFilelistState = stateFunc{"generate_filelist", (*StateMachine).generateFilelist}

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -1253,9 +1253,25 @@ var generatePackageManifestState = stateFunc{"generate_package_manifest", (*Stat
 func (stateMachine *StateMachine) generatePackageManifest() error {
 	classicStateMachine := stateMachine.parent.(*ClassicStateMachine)
 
-	outputPath := filepath.Join(stateMachine.commonFlags.OutputDir,
-		classicStateMachine.ImageDef.Artifacts.Manifest.ManifestName)
-	return generateClassicManifest(stateMachine.tempDirs.rootfs, outputPath, classicStateMachine.commonFlags.Debug)
+	if classicStateMachine.ImageDef.Artifacts.Manifest != nil {
+		outputPath := filepath.Join(stateMachine.commonFlags.OutputDir,
+			classicStateMachine.ImageDef.Artifacts.Manifest.ManifestName)
+		err := generateClassicManifest(stateMachine.tempDirs.rootfs, outputPath, classicStateMachine.commonFlags.Debug)
+		if err != nil {
+			return err
+		}
+	}
+
+	if classicStateMachine.ImageDef.Artifacts.ManifestV2 != nil {
+		outputPath := filepath.Join(stateMachine.commonFlags.OutputDir,
+			classicStateMachine.ImageDef.Artifacts.ManifestV2.ManifestName)
+		err := generateClassicManifestV2(stateMachine.tempDirs.rootfs, outputPath, classicStateMachine.commonFlags.Debug)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 var generateFilelistState = stateFunc{"generate_filelist", (*StateMachine).generateFilelist}

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2909,7 +2909,7 @@ func TestGeneratePackageManifest(t *testing.T) {
 	manifestBytes, err := os.ReadFile(manifestPath)
 	asserter.AssertErrNil(err, true)
 	// The order of packages shouldn't matter
-	examplePackages := []string{"foo 1.2", "bar 1.4-1ubuntu4.1", "libbaz 0.1.3ubuntu2"}
+	examplePackages := []string{"foo\t1.2", "bar\t1.4-1ubuntu4.1", "libbaz\t0.1.3ubuntu2"}
 	for _, pkg := range examplePackages {
 		if !strings.Contains(string(manifestBytes), pkg) {
 			t.Errorf("filesystem.manifest does not contain expected package: %s", pkg)
@@ -2967,7 +2967,7 @@ func TestFailedGeneratePackageManifest(t *testing.T) {
 		execCommand = exec.Command
 	})
 	err = stateMachine.generatePackageManifest()
-	asserter.AssertErrContains(err, "Error generating package manifest with command")
+	asserter.AssertErrContains(err, "Error generating package list with command")
 }
 
 // TestGenerateFilelist tests if classic image filelist generation works

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/snapcore/snapd/image"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 	"github.com/xeipuuv/gojsonschema"
 	"gopkg.in/yaml.v2"
@@ -2927,19 +2928,26 @@ func TestGeneratePackageManifest(t *testing.T) {
 			asserter.AssertErrNil(err, true)
 			t.Cleanup(func() { os.RemoveAll(stateMachine.stateMachineFlags.WorkDir) })
 
-			seedPath := filepath.Join(stateMachine.tempDirs.rootfs, "var", "lib", "snapd", "seed", "seed.yaml")
-			err = os.MkdirAll(filepath.Dir(seedPath), 0755)
-			asserter.AssertErrNil(err, true)
-			//nolint:gosec,G306
-			err = os.WriteFile(seedPath,
-				[]byte(`snaps:
-- name: snapd
-  snap-id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
-  channel: stable
-  contact: https://github.com/snapcore/snapd/issues
-  file: snapd_25939.snap`),
-				0644)
-			asserter.AssertErrNil(err, true)
+			seedOpen = func(seedDir string, label string) (seed.Seed, error) {
+				return &mockSeed{
+					snaps: []*seed.Snap{
+						{
+							Path: "snapd_25939.snap",
+							SideInfo: &snap.SideInfo{
+								RealName: "snapd",
+								Revision: snap.R(25939),
+							},
+							Channel: "stable",
+						},
+					},
+					loadAssertionsFailure: seed.ErrNoAssertions,
+					loadMetaFailure:       nil,
+				}, nil
+			}
+			t.Cleanup(func() {
+				seedOpen = seed.Open
+			})
+
 			err = stateMachine.generatePackageManifest()
 			asserter.AssertErrNil(err, true)
 
@@ -3010,6 +3018,109 @@ func TestFailedGeneratePackageManifest(t *testing.T) {
 	})
 	err = stateMachine.generatePackageManifest()
 	asserter.AssertErrContains(err, "Error generating package list with command")
+}
+
+// TestFailedGeneratePackageManifestV2 tests if classic manifest generation failures are reported
+func TestFailedGeneratePackageManifestV2(t *testing.T) {
+	asserter := helper.Asserter{T: t}
+	var stateMachine ClassicStateMachine
+	stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+	stateMachine.parent = &stateMachine
+	stateMachine.ImageDef = imagedefinition.ImageDefinition{
+		Architecture: arch.GetHostArch(),
+		Series:       getHostSuite(),
+		Rootfs: &imagedefinition.Rootfs{
+			Archive: "ubuntu",
+		},
+		Customization: &imagedefinition.Customization{},
+		Artifacts: &imagedefinition.Artifact{
+			ManifestV2: &imagedefinition.Manifest{
+				ManifestName: "filesystem.manifest",
+			},
+		},
+	}
+
+	// We need the output directory set for this
+	outputDir, err := os.MkdirTemp(testhelper.DefaultTmpDir, "ubuntu-image-")
+	asserter.AssertErrNil(err, true)
+	t.Cleanup(func() { os.RemoveAll(outputDir) })
+	stateMachine.commonFlags.OutputDir = outputDir
+
+	// Setup the mock for exec.Command - making those fail
+	testCaseName = "TestFailedGeneratePackageManifestV2"
+	execCommand = fakeExecCommand
+	t.Cleanup(func() {
+		execCommand = exec.Command
+	})
+	err = stateMachine.generatePackageManifest()
+	asserter.AssertErrContains(err, "Error generating package list with command")
+
+	// Setup the mock for exec.Command - making those succeed
+	testCaseName = "TestGeneratePackageManifestV2"
+	// Setup the mock for os.Create, making those fail
+	osCreate = mockCreate
+	t.Cleanup(func() {
+		osCreate = os.Create
+	})
+	err = stateMachine.generatePackageManifest()
+	asserter.AssertErrContains(err, "Error creating manifest file")
+
+	osCreate = os.Create
+	// Setup the mock seed - making those failed on seedOpen
+	seedOpen = func(seedDir string, label string) (seed.Seed, error) {
+		return nil, fmt.Errorf("fail")
+	}
+	t.Cleanup(func() {
+		seedOpen = seed.Open
+	})
+	err = stateMachine.generatePackageManifest()
+	asserter.AssertErrContains(err, "Error opening the seed file")
+
+	// Setup the mock seed - making those failed on LoadAssertion
+	seedOpen = func(seedDir string, label string) (seed.Seed, error) {
+		return &mockSeed{
+			snaps: []*seed.Snap{
+				{},
+			},
+			loadAssertionsFailure: fmt.Errorf("fail"),
+			loadMetaFailure:       nil,
+		}, nil
+	}
+	err = stateMachine.generatePackageManifest()
+	asserter.AssertErrContains(err, "Error loading assertions")
+
+	// Setup the mock seed - making those failed on LoadMeta
+	seedOpen = func(seedDir string, label string) (seed.Seed, error) {
+		return &mockSeed{
+			snaps: []*seed.Snap{
+				{},
+			},
+			loadAssertionsFailure: nil,
+			loadMetaFailure:       fmt.Errorf("fail"),
+		}, nil
+	}
+	err = stateMachine.generatePackageManifest()
+	asserter.AssertErrContains(err, "Error loading meta-data")
+
+	// Setup the mock seed - making those failed on Iter callback (bad path)
+	seedOpen = func(seedDir string, label string) (seed.Seed, error) {
+		return &mockSeed{
+			snaps: []*seed.Snap{
+				{
+					Path: "snapd25939.snap",
+					SideInfo: &snap.SideInfo{
+						RealName: "snapd",
+						Revision: snap.R(25939),
+					},
+					Channel: "stable",
+				},
+			},
+			loadAssertionsFailure: seed.ErrNoAssertions,
+			loadMetaFailure:       nil,
+		}, nil
+	}
+	err = stateMachine.generatePackageManifest()
+	asserter.AssertErrContains(err, "Error parsing snap filename")
 }
 
 // TestGenerateFilelist tests if classic image filelist generation works

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -2866,54 +2866,96 @@ UUID=1234-5678	/	ext4	defaults	0	0
 
 // TestGeneratePackageManifest tests if classic image manifest generation works
 func TestGeneratePackageManifest(t *testing.T) {
-	asserter := helper.Asserter{T: t}
-
-	// Setup the exec.Command mock
-	testCaseName = "TestGeneratePackageManifest"
-	execCommand = fakeExecCommand
-	t.Cleanup(func() {
-		execCommand = exec.Command
-	})
-	// We need the output directory set for this
-	outputDir, err := os.MkdirTemp(testhelper.DefaultTmpDir, "ubuntu-image-")
-	asserter.AssertErrNil(err, true)
-	t.Cleanup(func() { os.RemoveAll(outputDir) })
-
-	var stateMachine ClassicStateMachine
-	stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
-	stateMachine.parent = &stateMachine
-	stateMachine.commonFlags.OutputDir = outputDir
-	stateMachine.ImageDef = imagedefinition.ImageDefinition{
-		Architecture: arch.GetHostArch(),
-		Series:       getHostSuite(),
-		Rootfs: &imagedefinition.Rootfs{
-			Archive: "ubuntu",
-		},
-		Customization: &imagedefinition.Customization{},
-		Artifacts: &imagedefinition.Artifact{
-			Manifest: &imagedefinition.Manifest{
-				ManifestName: "filesystem.manifest",
+	testCases := []struct {
+		name            string
+		artifacts       *imagedefinition.Artifact
+		expectedContent []string
+	}{
+		{
+			name: "TestGeneratePackageManifest",
+			artifacts: &imagedefinition.Artifact{
+				Manifest: &imagedefinition.Manifest{
+					ManifestName: "filesystem.manifest",
+				},
 			},
+			expectedContent: []string{"foo 1.2", "bar 1.4-1ubuntu4.1", "libbaz 0.1.3ubuntu2"},
+		},
+		{
+			name: "TestGeneratePackageManifestV2",
+			artifacts: &imagedefinition.Artifact{
+				ManifestV2: &imagedefinition.Manifest{
+					ManifestName: "filesystem.manifest",
+				},
+			},
+			expectedContent: []string{"foo\t1.2", "bar\t1.4-1ubuntu4.1", "libbaz\t0.1.3ubuntu2", "snap:snapd\tstable\t25939"},
 		},
 	}
-	err = osMkdirAll(stateMachine.commonFlags.OutputDir, 0755)
-	asserter.AssertErrNil(err, true)
-	t.Cleanup(func() { os.RemoveAll(stateMachine.commonFlags.OutputDir) })
 
-	err = stateMachine.generatePackageManifest()
-	asserter.AssertErrNil(err, true)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			asserter := helper.Asserter{T: t}
 
-	os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
-	// Check if manifest file got generated and if it has expected contents
-	manifestPath := filepath.Join(stateMachine.commonFlags.OutputDir, "filesystem.manifest")
-	manifestBytes, err := os.ReadFile(manifestPath)
-	asserter.AssertErrNil(err, true)
-	// The order of packages shouldn't matter
-	examplePackages := []string{"foo\t1.2", "bar\t1.4-1ubuntu4.1", "libbaz\t0.1.3ubuntu2"}
-	for _, pkg := range examplePackages {
-		if !strings.Contains(string(manifestBytes), pkg) {
-			t.Errorf("filesystem.manifest does not contain expected package: %s", pkg)
-		}
+			// Setup the exec.Command mock
+			testCaseName = tc.name
+			execCommand = fakeExecCommand
+			t.Cleanup(func() {
+				execCommand = exec.Command
+			})
+			// We need the output directory set for this
+			outputDir, err := os.MkdirTemp(testhelper.DefaultTmpDir, "ubuntu-image-")
+			asserter.AssertErrNil(err, true)
+			t.Cleanup(func() { os.RemoveAll(outputDir) })
+
+			var stateMachine ClassicStateMachine
+			stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+			stateMachine.parent = &stateMachine
+			stateMachine.commonFlags.OutputDir = outputDir
+			stateMachine.ImageDef = imagedefinition.ImageDefinition{
+				Architecture: arch.GetHostArch(),
+				Series:       getHostSuite(),
+				Rootfs: &imagedefinition.Rootfs{
+					Archive: "ubuntu",
+				},
+				Customization: &imagedefinition.Customization{},
+				Artifacts:     tc.artifacts,
+			}
+			err = osMkdirAll(stateMachine.commonFlags.OutputDir, 0755)
+			asserter.AssertErrNil(err, true)
+			t.Cleanup(func() { os.RemoveAll(stateMachine.commonFlags.OutputDir) })
+
+			err = stateMachine.makeTemporaryDirectories()
+			asserter.AssertErrNil(err, true)
+			t.Cleanup(func() { os.RemoveAll(stateMachine.stateMachineFlags.WorkDir) })
+
+			seedPath := filepath.Join(stateMachine.tempDirs.rootfs, "var", "lib", "snapd", "seed", "seed.yaml")
+			err = os.MkdirAll(filepath.Dir(seedPath), 0755)
+			asserter.AssertErrNil(err, true)
+			//nolint:gosec,G306
+			err = os.WriteFile(seedPath,
+				[]byte(`snaps:
+- name: snapd
+  snap-id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+  channel: stable
+  contact: https://github.com/snapcore/snapd/issues
+  file: snapd_25939.snap`),
+				0644)
+			asserter.AssertErrNil(err, true)
+			err = stateMachine.generatePackageManifest()
+			asserter.AssertErrNil(err, true)
+
+			os.RemoveAll(stateMachine.stateMachineFlags.WorkDir)
+			// Check if manifest file got generated and if it has expected contents
+			manifestPath := filepath.Join(stateMachine.commonFlags.OutputDir, "filesystem.manifest")
+			manifestBytes, err := os.ReadFile(manifestPath)
+			asserter.AssertErrNil(err, true)
+			// The order of packages shouldn't matter
+			examplePackages := tc.expectedContent
+			for _, pkg := range examplePackages {
+				if !strings.Contains(string(manifestBytes), pkg) {
+					t.Errorf("filesystem.manifest does not contain expected package: %s", pkg)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -298,8 +298,34 @@ func WriteSnapManifest(snapsDir string, outputPath string) error {
 	return nil
 }
 
-// generateClassicManifest generate the classic manifest file for the given rootfs
+// generateClassicManifest generates the classic manifest file for the given rootfs
 func generateClassicManifest(rootfs string, outputPath string, debug bool) error {
+	adminDir := filepath.Join(rootfs, "var", "lib", "dpkg")
+	cmd := execCommand("dpkg-query", fmt.Sprintf("--admindir=%s", adminDir), "-W", "--showformat=${Package} ${Version}\n")
+	cmdOutput := helper.SetCommandOutput(cmd, debug)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Error generating package list with command \"%s\". "+
+			"Error is \"%s\". Full output below:\n%s",
+			cmd.String(), err.Error(), cmdOutput.String())
+	}
+
+	// write the output to a file on successful executions
+	manifest, err := osCreate(outputPath)
+	if err != nil {
+		return fmt.Errorf("Error creating manifest file: %s", err.Error())
+	}
+	defer manifest.Close()
+	_, err = manifest.Write(cmdOutput.Bytes())
+	if err != nil {
+		return fmt.Errorf("error writing the manifest file: %w", err)
+	}
+	return nil
+}
+
+// generateClassicManifestV2 generates the classic manifest file for the given rootfs
+// V2 has the same output as the livecd-rootfs tool.
+func generateClassicManifestV2(rootfs string, outputPath string, debug bool) error {
 	// get package list
 	adminDir := filepath.Join(rootfs, "var", "lib", "dpkg")
 	cmd := execCommand("dpkg-query", "--show", fmt.Sprintf("--admindir=%s", adminDir))
@@ -323,11 +349,14 @@ func generateClassicManifest(rootfs string, outputPath string, debug bool) error
 
 	seedPath := filepath.Join(rootfs, "var", "lib", "snapd", "seed", "seed.yaml")
 	if _, err := os.Stat(seedPath); err != nil {
-		// no seed.yaml file
-		return nil
+		if os.IsNotExist(err) {
+			// no seed.yaml file
+			return nil
+		}
+		return fmt.Errorf("Error stating the snap seed file: %w", err)
 	}
 	// read snap list from seed.yaml
-	data, err := os.ReadFile(seedPath)
+	data, err := osReadFile(seedPath)
 	if err != nil {
 		return fmt.Errorf("Error reading the snap seed file: %w", err)
 	}

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/timings"
+	"gopkg.in/yaml.v2"
 
 	"github.com/canonical/ubuntu-image/internal/helper"
 	"github.com/canonical/ubuntu-image/internal/imagedefinition"
@@ -293,6 +295,65 @@ func WriteSnapManifest(snapsDir string, outputPath string) error {
 			fmt.Fprintf(manifest, "%s %s\n", split[0], strings.TrimSuffix(split[1], ".snap"))
 		}
 	}
+	return nil
+}
+
+// generateClassicManifest generate the classic manifest file for the given rootfs
+func generateClassicManifest(rootfs string, outputPath string, debug bool) error {
+	// get package list
+	adminDir := filepath.Join(rootfs, "var", "lib", "dpkg")
+	cmd := execCommand("dpkg-query", "--show", fmt.Sprintf("--admindir=%s", adminDir))
+	cmdOutput := helper.SetCommandOutput(cmd, debug)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Error generating package list with command \"%s\". "+
+			"Error is \"%s\". Full output below:\n%s",
+			cmd.String(), err.Error(), cmdOutput.String())
+	}
+
+	// write package list to the manifest file
+	manifest, err := osCreate(outputPath)
+	if err != nil {
+		return fmt.Errorf("Error creating manifest file: %w", err)
+	}
+	defer manifest.Close()
+	_, err = manifest.Write(cmdOutput.Bytes())
+	if err != nil {
+		return fmt.Errorf("Error writing to the manifest file: %w", err)
+	}
+
+	seedPath := filepath.Join(rootfs, "var", "lib", "snapd", "seed", "seed.yaml")
+	if _, err := os.Stat(seedPath); err != nil {
+		// no seed.yaml file
+		return nil
+	}
+	// read snap list from seed.yaml
+	data, err := os.ReadFile(seedPath)
+	if err != nil {
+		return fmt.Errorf("Error reading the snap seed file: %w", err)
+	}
+	var seed struct {
+		Snaps []struct {
+			File    string `yaml:"file"`
+			Name    string `yaml:"name"`
+			Channel string `yaml:"channel"`
+		} `yaml:"snaps"`
+	}
+	if err := yaml.Unmarshal(data, &seed); err != nil {
+		return fmt.Errorf("Error parsing the snap seed file: %w", err)
+	}
+
+	// write snap list to the manifest
+	nonDigits := regexp.MustCompile(`[^0-9]`)
+	for _, snap := range seed.Snaps {
+		file := snap.File
+		revision := file[strings.LastIndex(file, "_")+1:]
+		revision = nonDigits.ReplaceAllString(revision, "")
+		// Write formatted line: "snap:<name>\t<channel>\t<revision>\n"
+		if _, err := fmt.Fprintf(manifest, "snap:%s\t%s\t%s\n", snap.Name, snap.Channel, revision); err != nil {
+			return fmt.Errorf("Error writing to the manifest file: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -21,7 +20,6 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/timings"
-	"gopkg.in/yaml.v2"
 
 	"github.com/canonical/ubuntu-image/internal/helper"
 	"github.com/canonical/ubuntu-image/internal/imagedefinition"
@@ -347,43 +345,40 @@ func generateClassicManifestV2(rootfs string, outputPath string, debug bool) err
 		return fmt.Errorf("Error writing to the manifest file: %w", err)
 	}
 
-	seedPath := filepath.Join(rootfs, "var", "lib", "snapd", "seed", "seed.yaml")
-	if _, err := os.Stat(seedPath); err != nil {
-		if os.IsNotExist(err) {
-			// no seed.yaml file
-			return nil
-		}
-		return fmt.Errorf("Error stating the snap seed file: %w", err)
-	}
-	// read snap list from seed.yaml
-	data, err := osReadFile(seedPath)
+	// open the seed and run LoadAssertions and LoadMeta to get a list of snaps
+	snapdDir := filepath.Join(rootfs, "var", "lib", "snapd")
+	seedDir := filepath.Join(snapdDir, "seed")
+	preseed, err := seedOpen(seedDir, "")
 	if err != nil {
-		return fmt.Errorf("Error reading the snap seed file: %w", err)
+		return fmt.Errorf("Error opening the seed file: %w", err)
 	}
-	var seed struct {
-		Snaps []struct {
-			File    string `yaml:"file"`
-			Name    string `yaml:"name"`
-			Channel string `yaml:"channel"`
-		} `yaml:"snaps"`
-	}
-	if err := yaml.Unmarshal(data, &seed); err != nil {
-		return fmt.Errorf("Error parsing the snap seed file: %w", err)
+	err = preseed.LoadAssertions(nil, nil)
+	if err != nil {
+		if err != seed.ErrNoAssertions {
+			return fmt.Errorf("Error loading assertions: %w", err)
+		}
+	} else {
+		measurer := timings.New(nil)
+		if err := preseed.LoadMeta(seed.AllModes, nil, measurer); err != nil {
+			return fmt.Errorf("Error loading meta-data: %w", err)
+		}
 	}
 
-	// write snap list to the manifest
-	nonDigits := regexp.MustCompile(`[^0-9]`)
-	for _, snap := range seed.Snaps {
-		file := snap.File
-		revision := file[strings.LastIndex(file, "_")+1:]
-		revision = nonDigits.ReplaceAllString(revision, "")
-		// Write formatted line: "snap:<name>\t<channel>\t<revision>\n"
-		if _, err := fmt.Fprintf(manifest, "snap:%s\t%s\t%s\n", snap.Name, snap.Channel, revision); err != nil {
+	// iterate over the snaps in the seed and add them to the manifest
+	return preseed.Iter(func(snap *seed.Snap) error {
+		base := strings.TrimSuffix(snap.Path, ".snap")
+		idx := strings.LastIndex(base, "_")
+		if idx == -1 {
+			return fmt.Errorf("Error parsing snap filename %q: expected format <name>_<revision>.snap", snap.Path)
+		}
+		revision := base[idx+1:]
+		// write formatted line: "snap:<name>\t<channel>\t<revision>\n"
+		if _, err := fmt.Fprintf(manifest, "snap:%s\t%s\t%s\n", snap.SnapName(), snap.Channel, revision); err != nil {
 			return fmt.Errorf("Error writing to the manifest file: %w", err)
 		}
-	}
+		return nil
+	})
 
-	return nil
 }
 
 // getHostSuite checks the release name of the host system to use as a default if --suite is not passed

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -13,10 +13,13 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil/mkfs"
 	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/timings"
 
 	"github.com/canonical/ubuntu-image/internal/helper"
 	"github.com/canonical/ubuntu-image/internal/imagedefinition"
@@ -1031,6 +1034,58 @@ func (m *mockEnvHolder) Setenv(key, value string) error {
 
 	return os.Setenv(key, value)
 }
+
+type mockSeed struct {
+	snaps                 []*seed.Snap
+	loadAssertionsFailure error
+	loadMetaFailure       error
+}
+
+func (f *mockSeed) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Batch) error) error {
+	return f.loadAssertionsFailure
+}
+
+func (f *mockSeed) LoadMeta(string, seed.ContainerHandler, timings.Measurer) error {
+	return f.loadMetaFailure
+}
+
+func (f *mockSeed) Iter(fnc func(sn *seed.Snap) error) error {
+	for _, sn := range f.snaps {
+		if err := fnc(sn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *mockSeed) Model() *asserts.Model { return nil }
+
+func (f *mockSeed) Brand() (*asserts.Account, error) { return nil, nil }
+
+func (f *mockSeed) SetParallelism(n int) {}
+
+func (f *mockSeed) LoadEssentialMeta([]snap.Type, timings.Measurer) error { return nil }
+
+func (f *mockSeed) LoadEssentialMetaWithSnapHandler([]snap.Type, seed.ContainerHandler, timings.Measurer) error {
+	return nil
+}
+
+func (f *mockSeed) UsesSnapdSnap() bool { return false }
+
+func (f *mockSeed) EssentialSnaps() []*seed.Snap { return f.snaps }
+
+func (f *mockSeed) ModeSnaps(mode string) ([]*seed.Snap, error) { return f.snaps, nil }
+
+func (f *mockSeed) ModeSnap(snapName, mode string) (*seed.Snap, error) {
+	for _, sn := range f.snaps {
+		if sn.SnapName() == snapName {
+			return sn, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *mockSeed) NumSnaps() int { return len(f.snaps) }
 
 func TestStateMachine_setMk2fsConf(t *testing.T) {
 	type fields struct {

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -216,7 +216,7 @@ func TestExecHelperProcess(t *testing.T) {
 	// instead on the actual arguments. And this makes sense to me
 	switch os.Getenv("TEST_CASE") {
 	case "TestGeneratePackageManifest":
-		fmt.Fprint(os.Stdout, "foo 1.2\nbar 1.4-1ubuntu4.1\nlibbaz 0.1.3ubuntu2\n")
+		fmt.Fprint(os.Stdout, "foo\t1.2\nbar\t1.4-1ubuntu4.1\nlibbaz\t0.1.3ubuntu2\n")
 	case "TestGenerateFilelist":
 		fmt.Fprint(os.Stdout, "/root\n/home\n/var")
 	case "TestFailedPreseedClassicImage",

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -225,6 +225,7 @@ func TestExecHelperProcess(t *testing.T) {
 		"TestFailedUpdateGrubLosetup",
 		"TestFailedMakeQcow2Image",
 		"TestFailedGeneratePackageManifest",
+		"TestFailedGeneratePackageManifestV2",
 		"TestFailedGenerateFilelist",
 		"TestFailedGerminate",
 		"TestFailedSetupLiveBuildCommands",

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -216,6 +216,8 @@ func TestExecHelperProcess(t *testing.T) {
 	// instead on the actual arguments. And this makes sense to me
 	switch os.Getenv("TEST_CASE") {
 	case "TestGeneratePackageManifest":
+		fmt.Fprint(os.Stdout, "foo 1.2\nbar 1.4-1ubuntu4.1\nlibbaz 0.1.3ubuntu2\n")
+	case "TestGeneratePackageManifestV2":
 		fmt.Fprint(os.Stdout, "foo\t1.2\nbar\t1.4-1ubuntu4.1\nlibbaz\t0.1.3ubuntu2\n")
 	case "TestGenerateFilelist":
 		fmt.Fprint(os.Stdout, "/root\n/home\n/var")

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.10.8"
+version: "3.10.9"
 grade: stable
 confinement: classic
 base: core24


### PR DESCRIPTION
Add a new artifact manifest-v2 for classic image with the same format as the one from livecd-rootfs.
Difference with the current manifest:
 * Use tab instead of space in the manifest
 * Add snaps to the manifest