### PR TITLE
WIP: Get verbose information out of debootstrap to help debug ports.u.c issues

### DIFF
--- a/debootstrap_wget_verbose.diff
+++ b/debootstrap_wget_verbose.diff
@@ -1,0 +1,11 @@
+--- functions	2026-03-12 12:24:16.826766227 +0100
++++ functions	2026-03-12 12:24:42.743834794 +0100
+@@ -94,7 +94,7 @@
+ 		ret=$({ { wget $@ 2>&1 >/dev/null || echo $? >&2; } | "$PKGDETAILS" "WGET%" "$PROGRESS_NOW" "$PROGRESS_NEXT" "$PROGRESS_END" >&3; } 2>&1)
+ 		: ${ret:=0}
+ 	else
+-		wget ${NVSWITCH:+"$NVSWITCH"} "$@"
++		wget ${NVSWITCH:+"$NVSWITCH"} -v "$@" >>"$TARGET/debootstrap/debootstrap.log"
+ 		ret=$?
+ 	fi
+ 	return $ret

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -178,8 +178,9 @@ func (stateMachine *StateMachine) createChroot() error {
 	debootstrapOutput := helper.SetCommandOutput(debootstrapCmd, classicStateMachine.commonFlags.Debug)
 
 	if err := debootstrapCmd.Run(); err != nil {
+		debootstrapLog, _ := os.ReadFile(filepath.Join(stateMachine.tempDirs.chroot, "debootstrap/debootstrap.log"))
 		return fmt.Errorf("Error running debootstrap command \"%s\". Error is \"%s\". Output is: \n%s",
-			debootstrapCmd.String(), err.Error(), debootstrapOutput.String())
+			debootstrapCmd.String(), err.Error(), debootstrapOutput.String() + "\ndebootstrap.log:\n" + string(debootstrapLog))
 	}
 
 	err := stateMachine.fixHostname()

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -53,6 +53,7 @@ parts:
       - libpython3-stdlib
       - libpython3.12-stdlib
       - libpython3.12-minimal
+      - patch
       - python3
       - python3-apt
       - python3-minimal
@@ -64,6 +65,8 @@ parts:
       git config --global --add safe.directory $CRAFT_PROJECT_DIR/.git
       craftctl default
     override-build: |
+      # Patch debootstrap to be more verbose when debugging network issues with ports.u.c
+      patch -d "$SNAPCRAFT_PART_INSTALL"/usr/share/debootstrap <./debootstrap_wget_verbose.diff
       mkdir -p "$SNAPCRAFT_PART_INSTALL"/etc/ubuntu-image/
       mv mkfs/confs "$SNAPCRAFT_PART_INSTALL"/etc/ubuntu-image/mkfs
       ins_bin=$SNAPCRAFT_PART_INSTALL/bin/


### PR DESCRIPTION
This is obviously not in a mergeable state. I'm just keeping this around in case we'd like to deploy it more at scale to help IS debug ports.u.c issues.

I have a PPA with a hacked `livecd-rootfs` embedding a manual build of that snap, usable for testing.
PPA: https://launchpad.net/~skia/+archive/ubuntu/test-livecd-rootfs
git branch: https://git.launchpad.net/~skia/livecd-rootfs/log/?h=skia/embedded_patched_ubuntu-image

@mwhudson @utkarsh2102 do you think something like that is worth pushing forward?
1. I believe at least the dump of `deboostrap.log` is a good improvement.
2. But putting the whole `wget` verbose output in there might be a bit too much.
3. Also, it would need to be at least somehow driven by the `--verbose` flag. 
4. Finally, that patching of `debootstrap` is very brittle, so proper work would include improving that as well.

cc @ben-ballot (this is more or less what's needed to get IP addresses shown in the logs when something goes wrong)