### PR TITLE
feat: Enable specifying a validation-set sequence number

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,10 @@
 ubuntu-image (3.10.9) UNRELEASED; urgency=medium
 
+  [ Alexis Cellier ]
   * Add manifest-v2 artifacts to generate a livecd-rootfs formatted manifest
+  [ Justin Cattle ]
+  * feat: Enable specifying a validation-set sequence number without locking it
+  in the model assertion
 
  -- Alexis Cellier <alexis.cellier@canonical.com>  Mon, 01 Jun 2026 23:25:20 +0000
 

--- a/internal/commands/snap.go
+++ b/internal/commands/snap.go
@@ -16,6 +16,7 @@ type SnapOpts struct {
 	Components                []string       `long:"comp" description:"Install extra components. These are passed through to \"snap prepare-image\"." value-name:"COMPONENT"`
 	CloudInit                 string         `long:"cloud-init" description:"cloud-config data to be copied to the image" value-name:"USER-DATA-FILE"`
 	Revisions                 map[string]int `long:"revision" description:"The revision of a specific snap to install in the image." value-name:"REVISION"`
+	Sequences                 map[string]int `long:"sequence" description:"The sequence of a specific validation-set to use when building the image." value-name:"SEQUENCE"`
 	SysfsOverlay              string         `long:"sysfs-overlay" description:"The optional sysfs overlay to used for preseeding. Directories from /sys/class/* and /sys/devices/platform will be bind-mounted to the chroot when preseeding"`
 	ExtraAssertionFilenames   []string       `long:"assertion" description:"Include extra assertions. Each usage indicates the path to a file containing the assertions. The paths are passed through to \"snap-prepare-image\" that validates their contents." value-name:"ASSERTION-FILE"`
 	AllowSnapdKernelMismatch  bool           `long:"allow-snapd-kernel-mismatch" description:"Allow mismatch between snap-bootstrap in the kernel and the snapd snap"`

--- a/internal/commands/snap.go
+++ b/internal/commands/snap.go
@@ -16,7 +16,7 @@ type SnapOpts struct {
 	Components                []string       `long:"comp" description:"Install extra components. These are passed through to \"snap prepare-image\"." value-name:"COMPONENT"`
 	CloudInit                 string         `long:"cloud-init" description:"cloud-config data to be copied to the image" value-name:"USER-DATA-FILE"`
 	Revisions                 map[string]int `long:"revision" description:"The revision of a specific snap to install in the image." value-name:"REVISION"`
-	Sequences                 map[string]int `long:"sequence" description:"The sequence of a specific validation-set to use when building the image." value-name:"SEQUENCE"`
+	Sequences                 map[string]int `long:"sequence" description:"The sequence of a specific validation-set to use when building the image. Validation-sets may be specified in short or long form; <name>:<sequence> or <account-id>/<name>:<sequence>." value-name:"SEQUENCE"`
 	SysfsOverlay              string         `long:"sysfs-overlay" description:"The optional sysfs overlay to used for preseeding. Directories from /sys/class/* and /sys/devices/platform will be bind-mounted to the chroot when preseeding"`
 	ExtraAssertionFilenames   []string       `long:"assertion" description:"Include extra assertions. Each usage indicates the path to a file containing the assertions. The paths are passed through to \"snap-prepare-image\" that validates their contents." value-name:"ASSERTION-FILE"`
 	AllowSnapdKernelMismatch  bool           `long:"allow-snapd-kernel-mismatch" description:"Allow mismatch between snap-bootstrap in the kernel and the snapd snap"`

--- a/internal/statemachine/snap_states.go
+++ b/internal/statemachine/snap_states.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/image"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/seed/seedwriter"
@@ -69,15 +70,45 @@ func (stateMachine *StateMachine) prepareImage() error {
 
 // imageOptsSeedManifest sets up the pre-provided manifest if revisions are passed
 func (snapStateMachine *SnapStateMachine) imageOptsSeedManifest() (*seedwriter.Manifest, error) {
-	if len(snapStateMachine.Opts.Revisions) == 0 {
+	if len(snapStateMachine.Opts.Revisions) == 0 && len(snapStateMachine.Opts.Sequences) == 0 {
 		return nil, nil
 	}
+
+	var modelValidationSets map[string]*asserts.ModelValidationSet
+	if len(snapStateMachine.Opts.Sequences) > 0 {
+		model, err := snapStateMachine.decodeModelAssertion()
+		if err != nil {
+			return nil, err
+		}
+
+		modelValidationSets = make(map[string]*asserts.ModelValidationSet, len(model.ValidationSets()))
+		for _, validationSet := range model.ValidationSets() {
+			if _, ok := modelValidationSets[validationSet.Name]; ok {
+				return nil, fmt.Errorf("error dealing with validation-set sequence %s: validation-set name is ambiguous in model assertion", validationSet.Name)
+			}
+			modelValidationSets[validationSet.Name] = validationSet
+		}
+	}
+
 	seedManifest := seedwriter.NewManifest()
 	for snapName, snapRev := range snapStateMachine.Opts.Revisions {
 		fmt.Printf("WARNING: revision %d for snap %s may not be the latest available version!\n", snapRev, snapName)
 		err := seedManifest.SetAllowedSnapRevision(snapName, snap.R(snapRev))
 		if err != nil {
 			return nil, fmt.Errorf("error dealing with snap revision %s: %w", snapName, err)
+		}
+	}
+
+	for validationSetName, sequence := range snapStateMachine.Opts.Sequences {
+		validationSet, ok := modelValidationSets[validationSetName]
+		if !ok {
+			return nil, fmt.Errorf("error dealing with validation-set sequence %s: validation-set not present in model assertion", validationSetName)
+		}
+
+		fmt.Printf("WARNING: sequence %d for validation-set %s may not be the latest available sequence!\n", sequence, validationSetName)
+		err := seedManifest.SetAllowedValidationSet(validationSet.AccountID, validationSet.Name, sequence, false)
+		if err != nil {
+			return nil, fmt.Errorf("error dealing with validation-set sequence %s: %w", validationSetName, err)
 		}
 	}
 

--- a/internal/statemachine/snap_states.go
+++ b/internal/statemachine/snap_states.go
@@ -68,7 +68,7 @@ func (stateMachine *StateMachine) prepareImage() error {
 	return nil
 }
 
-// imageOptsSeedManifest sets up the pre-provided manifest if revisions are passed
+// imageOptsSeedManifest sets up the pre-provided manifest when snap revision overrides or validation-set sequence overrides are passed
 func (snapStateMachine *SnapStateMachine) imageOptsSeedManifest() (*seedwriter.Manifest, error) {
 	if len(snapStateMachine.Opts.Revisions) == 0 && len(snapStateMachine.Opts.Sequences) == 0 {
 		return nil, nil

--- a/internal/statemachine/snap_states.go
+++ b/internal/statemachine/snap_states.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/image"
@@ -74,20 +75,14 @@ func (snapStateMachine *SnapStateMachine) imageOptsSeedManifest() (*seedwriter.M
 		return nil, nil
 	}
 
-	var modelValidationSets map[string]*asserts.ModelValidationSet
+	var modelValidationSets []*asserts.ModelValidationSet
 	if len(snapStateMachine.Opts.Sequences) > 0 {
 		model, err := snapStateMachine.decodeModelAssertion()
 		if err != nil {
 			return nil, err
 		}
 
-		modelValidationSets = make(map[string]*asserts.ModelValidationSet, len(model.ValidationSets()))
-		for _, validationSet := range model.ValidationSets() {
-			if _, ok := modelValidationSets[validationSet.Name]; ok {
-				return nil, fmt.Errorf("error dealing with validation-set sequence %s: validation-set name is ambiguous in model assertion", validationSet.Name)
-			}
-			modelValidationSets[validationSet.Name] = validationSet
-		}
+		modelValidationSets = model.ValidationSets()
 	}
 
 	seedManifest := seedwriter.NewManifest()
@@ -100,19 +95,49 @@ func (snapStateMachine *SnapStateMachine) imageOptsSeedManifest() (*seedwriter.M
 	}
 
 	for validationSetName, sequence := range snapStateMachine.Opts.Sequences {
-		validationSet, ok := modelValidationSets[validationSetName]
-		if !ok {
-			return nil, fmt.Errorf("error dealing with validation-set sequence %s: validation-set not present in model assertion", validationSetName)
+		validationSet, err := resolveValidationSetSequence(validationSetName, modelValidationSets)
+		if err != nil {
+			return nil, fmt.Errorf("error dealing with validation-set sequence %s: %w", validationSetName, err)
 		}
 
 		fmt.Printf("WARNING: sequence %d for validation-set %s may not be the latest available sequence!\n", sequence, validationSetName)
-		err := seedManifest.SetAllowedValidationSet(validationSet.AccountID, validationSet.Name, sequence, false)
+		// allow the validation-set to be updated after image building
+		const pinned = false
+		err = seedManifest.SetAllowedValidationSet(validationSet.AccountID, validationSet.Name, sequence, pinned)
 		if err != nil {
 			return nil, fmt.Errorf("error dealing with validation-set sequence %s: %w", validationSetName, err)
 		}
 	}
 
 	return seedManifest, nil
+}
+
+func resolveValidationSetSequence(validationSetRef string, modelValidationSets []*asserts.ModelValidationSet) (*asserts.ModelValidationSet, error) {
+	accountID, validationSetName, hasAccountID := strings.Cut(validationSetRef, "/")
+	if !hasAccountID {
+		var match *asserts.ModelValidationSet
+		for _, validationSet := range modelValidationSets {
+			if validationSet.Name != validationSetRef {
+				continue
+			}
+			if match != nil {
+				return nil, fmt.Errorf("validation-set name is ambiguous in model assertion")
+			}
+			match = validationSet
+		}
+		if match == nil {
+			return nil, fmt.Errorf("validation-set not present in model assertion")
+		}
+		return match, nil
+	}
+
+	for _, validationSet := range modelValidationSets {
+		if validationSet.AccountID == accountID && validationSet.Name == validationSetName {
+			return validationSet, nil
+		}
+	}
+
+	return nil, fmt.Errorf("validation-set not present in model assertion")
 }
 
 // imageOptsCustomizations prepares the Customizations options to give to image.Prepare

--- a/internal/statemachine/snap_test.go
+++ b/internal/statemachine/snap_test.go
@@ -972,6 +972,95 @@ func TestPreseedFlag(t *testing.T) {
 	asserter.AssertErrNil(err, true)
 }
 
+func TestValidationSetSequencesFlag(t *testing.T) {
+	asserter := helper.Asserter{T: t}
+	restoreCWD := testhelper.SaveCWD()
+	defer restoreCWD()
+
+	var calledOpts *image.Options
+	imagePrepare = func(opts *image.Options) error {
+		calledOpts = opts
+		return nil
+	}
+	defer func() {
+		imagePrepare = image.Prepare
+	}()
+
+	var stateMachine SnapStateMachine
+	stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+	stateMachine.parent = &stateMachine
+	stateMachine.Args.ModelAssertion = filepath.Join("testdata", "modelAssertionValidationSets")
+	workDir, err := os.MkdirTemp(testhelper.DefaultTmpDir, "ubuntu-image-")
+	asserter.AssertErrNil(err, true)
+	t.Cleanup(func() { os.RemoveAll(workDir) })
+	stateMachine.stateMachineFlags.WorkDir = workDir
+	stateMachine.stateMachineFlags.Thru = "prepare_image"
+	stateMachine.Opts.Sequences = map[string]int{
+		"test-validation-set": 7,
+	}
+
+	err = stateMachine.Setup()
+	asserter.AssertErrNil(err, true)
+
+	err = stateMachine.Run()
+	asserter.AssertErrNil(err, true)
+
+	if calledOpts == nil {
+		t.Fatal("options passed to image.Prepare are nil")
+	}
+
+	if calledOpts.SeedManifest == nil {
+		t.Fatal("expected SeedManifest to be populated")
+	}
+
+	expectedValidationSets := calledOpts.SeedManifest.AllowedValidationSets()
+	if len(expectedValidationSets) != 1 {
+		t.Fatalf("expected 1 validation-set override, got %d", len(expectedValidationSets))
+	}
+
+	expected := expectedValidationSets[0]
+	if expected.AccountID != "CA5GLZgNQWPhspDQK63Er46Uxz2SO7ez" {
+		t.Fatalf("expected account-id %q, got %q", "CA5GLZgNQWPhspDQK63Er46Uxz2SO7ez", expected.AccountID)
+	}
+	if expected.Name != "test-validation-set" {
+		t.Fatalf("expected validation-set name %q, got %q", "test-validation-set", expected.Name)
+	}
+	if expected.Sequence != 7 {
+		t.Fatalf("expected sequence %d, got %d", 7, expected.Sequence)
+	}
+	if expected.Pinned {
+		t.Fatal("expected validation-set sequence override to be non-pinned")
+	}
+
+	err = stateMachine.Teardown()
+	asserter.AssertErrNil(err, true)
+}
+
+func TestValidationSetSequencesFlagMissingValidationSet(t *testing.T) {
+	asserter := helper.Asserter{T: t}
+	restoreCWD := testhelper.SaveCWD()
+	defer restoreCWD()
+
+	var stateMachine SnapStateMachine
+	stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+	stateMachine.parent = &stateMachine
+	stateMachine.Args.ModelAssertion = filepath.Join("testdata", "modelAssertionValidationSets")
+	workDir, err := os.MkdirTemp(testhelper.DefaultTmpDir, "ubuntu-image-")
+	asserter.AssertErrNil(err, true)
+	t.Cleanup(func() { os.RemoveAll(workDir) })
+	stateMachine.stateMachineFlags.WorkDir = workDir
+	stateMachine.stateMachineFlags.Thru = "prepare_image"
+	stateMachine.Opts.Sequences = map[string]int{
+		"missing-validation-set": 7,
+	}
+
+	err = stateMachine.Setup()
+	asserter.AssertErrNil(err, true)
+
+	err = stateMachine.Run()
+	asserter.AssertErrContains(err, "error dealing with validation-set sequence missing-validation-set: validation-set not present in model assertion")
+}
+
 func TestSnapStateMachine_decodeModelAssertion(t *testing.T) {
 	type fields struct {
 		Args commands.SnapArgs

--- a/internal/statemachine/snap_test.go
+++ b/internal/statemachine/snap_test.go
@@ -1036,6 +1036,149 @@ func TestValidationSetSequencesFlag(t *testing.T) {
 	asserter.AssertErrNil(err, true)
 }
 
+func TestValidationSetSequencesFlagLongForm(t *testing.T) {
+	asserter := helper.Asserter{T: t}
+	restoreCWD := testhelper.SaveCWD()
+	defer restoreCWD()
+
+	var calledOpts *image.Options
+	imagePrepare = func(opts *image.Options) error {
+		calledOpts = opts
+		return nil
+	}
+	defer func() {
+		imagePrepare = image.Prepare
+	}()
+
+	var stateMachine SnapStateMachine
+	stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+	stateMachine.parent = &stateMachine
+	stateMachine.Args.ModelAssertion = filepath.Join("testdata", "modelAssertionValidationSets")
+	workDir, err := os.MkdirTemp(testhelper.DefaultTmpDir, "ubuntu-image-")
+	asserter.AssertErrNil(err, true)
+	t.Cleanup(func() { os.RemoveAll(workDir) })
+	stateMachine.stateMachineFlags.WorkDir = workDir
+	stateMachine.stateMachineFlags.Thru = "prepare_image"
+	stateMachine.Opts.Sequences = map[string]int{
+		"developer1/alternate-validation-set": 11,
+	}
+
+	err = stateMachine.Setup()
+	asserter.AssertErrNil(err, true)
+
+	err = stateMachine.Run()
+	asserter.AssertErrNil(err, true)
+
+	if calledOpts == nil {
+		t.Fatal("options passed to image.Prepare are nil")
+	}
+
+	if calledOpts.SeedManifest == nil {
+		t.Fatal("expected SeedManifest to be populated")
+	}
+
+	validationSets := calledOpts.SeedManifest.AllowedValidationSets()
+	if len(validationSets) != 1 {
+		t.Fatalf("expected 1 validation-set override, got %d", len(validationSets))
+	}
+
+	validationSet := validationSets[0]
+	if validationSet.AccountID != "developer1" {
+		t.Fatalf("expected account-id %q, got %q", "developer1", validationSet.AccountID)
+	}
+	if validationSet.Name != "alternate-validation-set" {
+		t.Fatalf("expected validation-set name %q, got %q", "alternate-validation-set", validationSet.Name)
+	}
+	if validationSet.Sequence != 11 {
+		t.Fatalf("expected sequence %d, got %d", 11, validationSet.Sequence)
+	}
+	if validationSet.Pinned {
+		t.Fatal("expected validation-set sequence override to be non-pinned")
+	}
+
+	err = stateMachine.Teardown()
+	asserter.AssertErrNil(err, true)
+}
+
+func TestValidationSetSequencesFlagAmbiguousShortForm(t *testing.T) {
+	asserter := helper.Asserter{T: t}
+	restoreCWD := testhelper.SaveCWD()
+	defer restoreCWD()
+
+	var stateMachine SnapStateMachine
+	stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+	stateMachine.parent = &stateMachine
+	stateMachine.Args.ModelAssertion = filepath.Join("testdata", "modelAssertionValidationSetsAmbiguous")
+	workDir, err := os.MkdirTemp(testhelper.DefaultTmpDir, "ubuntu-image-")
+	asserter.AssertErrNil(err, true)
+	t.Cleanup(func() { os.RemoveAll(workDir) })
+	stateMachine.stateMachineFlags.WorkDir = workDir
+	stateMachine.stateMachineFlags.Thru = "prepare_image"
+	stateMachine.Opts.Sequences = map[string]int{
+		"shared-validation-set": 7,
+	}
+
+	err = stateMachine.Setup()
+	asserter.AssertErrNil(err, true)
+
+	err = stateMachine.Run()
+	asserter.AssertErrContains(err, "error dealing with validation-set sequence shared-validation-set: validation-set name is ambiguous in model assertion")
+}
+
+func TestValidationSetSequencesFlagLongFormAmbiguousName(t *testing.T) {
+	asserter := helper.Asserter{T: t}
+	restoreCWD := testhelper.SaveCWD()
+	defer restoreCWD()
+
+	var calledOpts *image.Options
+	imagePrepare = func(opts *image.Options) error {
+		calledOpts = opts
+		return nil
+	}
+	defer func() {
+		imagePrepare = image.Prepare
+	}()
+
+	var stateMachine SnapStateMachine
+	stateMachine.commonFlags, stateMachine.stateMachineFlags = helper.InitCommonOpts()
+	stateMachine.parent = &stateMachine
+	stateMachine.Args.ModelAssertion = filepath.Join("testdata", "modelAssertionValidationSetsAmbiguous")
+	workDir, err := os.MkdirTemp(testhelper.DefaultTmpDir, "ubuntu-image-")
+	asserter.AssertErrNil(err, true)
+	t.Cleanup(func() { os.RemoveAll(workDir) })
+	stateMachine.stateMachineFlags.WorkDir = workDir
+	stateMachine.stateMachineFlags.Thru = "prepare_image"
+	stateMachine.Opts.Sequences = map[string]int{
+		"developer1/shared-validation-set": 9,
+	}
+
+	err = stateMachine.Setup()
+	asserter.AssertErrNil(err, true)
+
+	err = stateMachine.Run()
+	asserter.AssertErrNil(err, true)
+
+	if calledOpts == nil {
+		t.Fatal("options passed to image.Prepare are nil")
+	}
+
+	validationSets := calledOpts.SeedManifest.AllowedValidationSets()
+	if len(validationSets) != 1 {
+		t.Fatalf("expected 1 validation-set override, got %d", len(validationSets))
+	}
+
+	validationSet := validationSets[0]
+	if validationSet.AccountID != "developer1" {
+		t.Fatalf("expected account-id %q, got %q", "developer1", validationSet.AccountID)
+	}
+	if validationSet.Name != "shared-validation-set" {
+		t.Fatalf("expected validation-set name %q, got %q", "shared-validation-set", validationSet.Name)
+	}
+	if validationSet.Sequence != 9 {
+		t.Fatalf("expected sequence %d, got %d", 9, validationSet.Sequence)
+	}
+}
+
 func TestValidationSetSequencesFlagMissingValidationSet(t *testing.T) {
 	asserter := helper.Asserter{T: t}
 	restoreCWD := testhelper.SaveCWD()

--- a/internal/statemachine/snap_test.go
+++ b/internal/statemachine/snap_test.go
@@ -1013,22 +1013,22 @@ func TestValidationSetSequencesFlag(t *testing.T) {
 		t.Fatal("expected SeedManifest to be populated")
 	}
 
-	expectedValidationSets := calledOpts.SeedManifest.AllowedValidationSets()
-	if len(expectedValidationSets) != 1 {
-		t.Fatalf("expected 1 validation-set override, got %d", len(expectedValidationSets))
+	validationSets := calledOpts.SeedManifest.AllowedValidationSets()
+	if len(validationSets) != 1 {
+		t.Fatalf("expected 1 validation-set override, got %d", len(validationSets))
 	}
 
-	expected := expectedValidationSets[0]
-	if expected.AccountID != "CA5GLZgNQWPhspDQK63Er46Uxz2SO7ez" {
-		t.Fatalf("expected account-id %q, got %q", "CA5GLZgNQWPhspDQK63Er46Uxz2SO7ez", expected.AccountID)
+	validationSet := validationSets[0]
+	if validationSet.AccountID != "CA5GLZgNQWPhspDQK63Er46Uxz2SO7ez" {
+		t.Fatalf("expected account-id %q, got %q", "CA5GLZgNQWPhspDQK63Er46Uxz2SO7ez", validationSet.AccountID)
 	}
-	if expected.Name != "test-validation-set" {
-		t.Fatalf("expected validation-set name %q, got %q", "test-validation-set", expected.Name)
+	if validationSet.Name != "test-validation-set" {
+		t.Fatalf("expected validation-set name %q, got %q", "test-validation-set", validationSet.Name)
 	}
-	if expected.Sequence != 7 {
-		t.Fatalf("expected sequence %d, got %d", 7, expected.Sequence)
+	if validationSet.Sequence != 7 {
+		t.Fatalf("expected sequence %d, got %d", 7, validationSet.Sequence)
 	}
-	if expected.Pinned {
+	if validationSet.Pinned {
 		t.Fatal("expected validation-set sequence override to be non-pinned")
 	}
 

--- a/internal/statemachine/testdata/modelAssertionValidationSets
+++ b/internal/statemachine/testdata/modelAssertionValidationSets
@@ -1,0 +1,50 @@
+type: model
+authority-id: CA5GLZgNQWPhspDQK63Er46Uxz2SO7ez
+series: 16
+brand-id: CA5GLZgNQWPhspDQK63Er46Uxz2SO7ez
+model: pc
+architecture: amd64
+base: core20
+grade: signed
+validation-sets:
+  -
+    name: test-validation-set
+    mode: prefer-enforce
+  -
+    account-id: developer1
+    name: alternate-validation-set
+    mode: prefer-enforce
+snaps:
+  -
+    default-channel: 20/edge
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: latest/edge
+    id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
+    name: core20
+    type: base
+  -
+    default-channel: 20/edge
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+timestamp: 2020-11-27T15:30:00Z
+sign-key-sha3-384: x1Tnl94nkgb-rMDs_l63gvgkLYGjXKfpkCCIQZwJ72-LR6X6OrSvNS9z2WS1lAGz
+
+AcLBcwQAAQoAHRYhBJABFPajYkcbyArNXdOZThAVY89JBQJg8FFtAAoJENOZThAVY89JlQsQAKnQ
+9GBlLU2P0TQr0a+Jw/WXk9jsVv1SSnPJQ1tQd8i9PZ9Z5xmztD/6FWEKk0goLhTgDYbIvrwVALEI
+YsXFLrFgG0/x5R96LO9JqQNG3qHUfwnXddS0NwjDHKNINs53r+bqKp0hFU+17GuiMIEoVcRCgEBd
+8bp6IMJpvulBaMu5xdRQqi+KWYIjHlcHd5lxYhdIT2K06d6fRTVS3hlwFPpRKrnm/Enw17bfAq/0
+M8t3TICMclTt4AF/PALuZJqdcP5C7ya88Rott+5DyTX/9mNtLw9C/+XZSI9x32o/e+MJagNXPLxE
+K7moO2lrQeVNO9G/v3x8qRpxwbZcrm9nulHPUXjINWAa7jFmfdyyGPNmff9N7mvAQH5HObnDxpht
+LSDnYskT2/xAF9MzLZf1N79URvh11VOokSla/YnWCswjgrqBLntq8JVrsnZSRjPczBnKIoAcBitr
+jQKzx6WyTd+9y8vxXWwyBnJ5c7lBcbT/FeFoXaSrLm2zyc7kArgfhsSlgOy8aW9akHcmwpSXlYAH
+EwDpT8Qhj/Nl5RXjPF38x/1bGJYHasSM7bnGjw6k7OYgXyKhcV5dR+Jd3AlOJ3tnSiPR9fJ5kkVb
+Mv/hvqbhjZtLiKl/60iz1FAsXlNG/SfXZzadWmKuEiGS/pmeyqgy/BJLNVffeaLRU19eD5R6

--- a/internal/statemachine/testdata/modelAssertionValidationSetsAmbiguous
+++ b/internal/statemachine/testdata/modelAssertionValidationSetsAmbiguous
@@ -1,0 +1,51 @@
+type: model
+authority-id: CA5GLZgNQWPhspDQK63Er46Uxz2SO7ez
+series: 16
+brand-id: CA5GLZgNQWPhspDQK63Er46Uxz2SO7ez
+model: pc
+architecture: amd64
+base: core20
+grade: signed
+validation-sets:
+  -
+    account-id: developer1
+    name: shared-validation-set
+    mode: prefer-enforce
+  -
+    account-id: developer2
+    name: shared-validation-set
+    mode: prefer-enforce
+snaps:
+  -
+    default-channel: 20/edge
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: latest/edge
+    id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
+    name: core20
+    type: base
+  -
+    default-channel: 20/edge
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+timestamp: 2020-11-27T15:30:00Z
+sign-key-sha3-384: x1Tnl94nkgb-rMDs_l63gvgkLYGjXKfpkCCIQZwJ72-LR6X6OrSvNS9z2WS1lAGz
+
+AcLBcwQAAQoAHRYhBJABFPajYkcbyArNXdOZThAVY89JBQJg8FFtAAoJENOZThAVY89JlQsQAKnQ
+9GBlLU2P0TQr0a+Jw/WXk9jsVv1SSnPJQ1tQd8i9PZ9Z5xmztD/6FWEKk0goLhTgDYbIvrwVALEI
+YsXFLrFgG0/x5R96LO9JqQNG3qHUfwnXddS0NwjDHKNINs53r+bqKp0hFU+17GuiMIEoVcRCgEBd
+8bp6IMJpvulBaMu5xdRQqi+KWYIjHlcHd5lxYhdIT2K06d6fRTVS3hlwFPpRKrnm/Enw17bfAq/0
+M8t3TICMclTt4AF/PALuZJqdcP5C7ya88Rott+5DyTX/9mNtLw9C/+XZSI9x32o/e+MJagNXPLxE
+K7moO2lrQeVNO9G/v3x8qRpxwbZcrm9nulHPUXjINWAa7jFmfdyyGPNmff9N7mvAQH5HObnDxpht
+LSDnYskT2/xAF9MzLZf1N79URvh11VOokSla/YnWCswjgrqBLntq8JVrsnZSRjPczBnKIoAcBitr
+jQKzx6WyTd+9y8vxXWwyBnJ5c7lBcbT/FeFoXaSrLm2zyc7kArgfhsSlgOy8aW9akHcmwpSXlYAH
+EwDpT8Qhj/Nl5RXjPF38x/1bGJYHasSM7bnGjw6k7OYgXyKhcV5dR+Jd3AlOJ3tnSiPR9fJ5kkVb
+Mv/hvqbhjZtLiKl/60iz1FAsXlNG/SfXZzadWmKuEiGS/pmeyqgy/BJLNVffeaLRU19eD5R6


### PR DESCRIPTION
Add support for specifying the sequence number of given validation-set, but without having to lock the sequence number in the the model itself.

The new `--sequence` option is used to allow specifying a sequence number for a named valediction-set.  This is similar to the `--revision` option allows specifying revisions of for named snaps. 

```
--sequence=my-validatin-set:123 --sequence=my-other-validatin-set:456
```

If you specify the sequence number for the validation-set in the model assertion itself, then the device is locked to that for the life of the model on that device.  This allows setting an install-time sequence number, and still allowing the sequence to changed later on  a given device based on the specific model in question.

When specifying the validation-set name, you cam use either the short form [ `<name>` ], or the long form [ `<account>/<name>` ].  The long form is optional unless you need to configure two validations-sets sequences with the same name from different accounts.