### PR TITLE
internal/imagedefinition: add use-part-label boolean

### DIFF
--- a/internal/imagedefinition/README.rst
+++ b/internal/imagedefinition/README.rst
@@ -284,6 +284,8 @@ The following specification defines what is supported in the YAML:
         -
           # the value of LABEL= for the fstab entry
           label: <string>
+          # instead of using LABEL=, use PARTLABEL= for the fstab entry
+          use-part-label: <bool> (optional)
           # where to mount the partition
           mountpoint: <string>
           # the filesystem type

--- a/internal/imagedefinition/image_definition.go
+++ b/internal/imagedefinition/image_definition.go
@@ -129,6 +129,7 @@ type Manual struct {
 // Fstab defines the information that gets rendered into an fstab
 type Fstab struct {
 	Label        string `yaml:"label"           json:"Label"`
+	UsePartLabel bool   `yaml:"use-part-label"  json:"UsePartLabel,omitempty"`
 	Mountpoint   string `yaml:"mountpoint"      json:"Mountpoint"`
 	FSType       string `yaml:"filesystem-type" json:"FSType"`
 	MountOptions string `yaml:"mount-options"   json:"MountOptions" default:"defaults"`

--- a/internal/statemachine/classic_states.go
+++ b/internal/statemachine/classic_states.go
@@ -758,7 +758,14 @@ func (stateMachine *StateMachine) customizeFstab() error {
 		} else {
 			dumpString = "0"
 		}
-		fstabEntry := fmt.Sprintf("LABEL=%s\t%s\t%s\t%s\t%s\t%d",
+		var matchField string
+		if fstab.UsePartLabel {
+			matchField = "PARTLABEL"
+		} else {
+			matchField = "LABEL"
+		}
+		fstabEntry := fmt.Sprintf("%s=%s\t%s\t%s\t%s\t%s\t%d",
+			matchField,
 			fstab.Label,
 			fstab.Mountpoint,
 			fstab.FSType,

--- a/internal/statemachine/classic_test.go
+++ b/internal/statemachine/classic_test.go
@@ -4893,6 +4893,22 @@ func TestCustomizeFstab(t *testing.T) {
 LABEL=system-boot	/boot/firmware	vfat	defaults	0	1
 `,
 		},
+		{
+			name: "one entry with use-part-label",
+			fstab: []*imagedefinition.Fstab{
+				{
+					Label:        "writable",
+                    UsePartLabel: true,
+					Mountpoint:   "/",
+					FSType:       "ext4",
+					MountOptions: "defaults",
+					Dump:         true,
+					FsckOrder:    1,
+				},
+			},
+			expectedFstab: `PARTLABEL=writable	/	ext4	defaults	1	1
+`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This new option value allow to change the LABEL=xxx fstab entry to PARTLABEL=xxx one, making systemd mounting the device using its partition label, and not its filesystem label.
This allow to do manipulate partition without filesystem or unknown one. This permet for example:
 * Mounting a filesystem that only have a partition label;
 * Generate the filesystem (if you add x-systemd.makefs option) on first boot for that partition.