### PR TITLE
feat: adapt to new mkfs API with context and options struct

### DIFF
--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -2,6 +2,7 @@ package statemachine
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/osutil/mkfs"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/timings"
 
@@ -209,17 +211,20 @@ func makeFS(structure *gadget.VolumeStructure, contentRoot string, partImg strin
 		return fmt.Errorf("Error preparing env for mkfs: %s", err.Error())
 	}
 
+	opts := &mkfs.MakeOptions{
+		Label:      structure.Label,
+		DeviceSize: structure.Size,
+		SectorSize: sectorSize,
+	}
 	if hasC {
-		err := mkfsMakeWithContent(structure.Filesystem, partImg, structure.Label,
-			contentRoot, structure.Size, sectorSize)
-		if err != nil {
+		opts.ContentRootDir = contentRoot
+	}
+
+	err = mkfsMake(context.TODO(), structure.Filesystem, partImg, opts)
+	if err != nil {
+		if hasC {
 			return fmt.Errorf("Error running mkfs with content: %s", err.Error())
 		}
-		return nil
-	}
-	err = mkfsMake(structure.Filesystem, partImg, structure.Label,
-		structure.Size, sectorSize)
-	if err != nil {
 		return fmt.Errorf("Error running mkfs: %s", err.Error())
 	}
 

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -132,22 +132,17 @@ func TestFailedCopyStructureContent(t *testing.T) {
 	Mke2fsConfigEnv = OldMke2fsConfigEnv
 	Mke2fsBasepath = OldMke2fsBasepath
 
-	// mock gadget.MkfsWithContent
-	mkfsMakeWithContent = mockMkfsWithContent
-	t.Cleanup(func() {
-		mkfsMakeWithContent = mkfs.MakeWithContent
-	})
-	err = stateMachine.copyStructureContent(&rootfsStruct, "",
-		filepath.Join(testhelper.DefaultTmpDir, uuid.NewString()+".img"))
-	asserter.AssertErrContains(err, "Error running mkfs with content")
-	mkfsMakeWithContent = mkfs.MakeWithContent
-
-	// mock mkfs.Mkfs
-	rootfsStruct.Content = nil // to trigger the "empty partition" case
+	// mock mkfs.Make
 	mkfsMake = mockMkfs
 	t.Cleanup(func() {
 		mkfsMake = mkfs.Make
 	})
+
+	err = stateMachine.copyStructureContent(&rootfsStruct, "",
+		filepath.Join(testhelper.DefaultTmpDir, uuid.NewString()+".img"))
+	asserter.AssertErrContains(err, "Error running mkfs with content")
+
+	rootfsStruct.Content = nil // to trigger the "empty partition" case
 	err = stateMachine.copyStructureContent(&rootfsStruct, "",
 		filepath.Join(testhelper.DefaultTmpDir, uuid.NewString()+".img"))
 	asserter.AssertErrContains(err, "Error running mkfs")

--- a/internal/statemachine/state_machine.go
+++ b/internal/statemachine/state_machine.go
@@ -63,7 +63,6 @@ var osSetenv = os.Setenv
 var osutilCopyFile = osutil.CopyFile
 var osutilCopySpecialFile = osutil.CopySpecialFile
 var execCommand = exec.Command
-var mkfsMakeWithContent = mkfs.MakeWithContent
 var mkfsMake = mkfs.Make
 var diskfsCreate = diskfs.Create
 var randRead = rand.Read

--- a/internal/statemachine/state_machine_test.go
+++ b/internal/statemachine/state_machine_test.go
@@ -1,6 +1,7 @@
 package statemachine
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/image"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/mkfs"
 	"github.com/snapcore/snapd/seed"
 	"github.com/xeipuuv/gojsonschema"
 
@@ -93,10 +95,7 @@ func mockNewMountedFilesystemWriter(*gadget.LaidOutStructure, *gadget.LaidOutStr
 	gadget.ContentObserver) (*gadget.MountedFilesystemWriter, error) {
 	return nil, fmt.Errorf("Test Error")
 }
-func mockMkfsWithContent(typ, img, label, contentRootDir string, deviceSize, sectorSize quantity.Size) error {
-	return fmt.Errorf("Test Error")
-}
-func mockMkfs(typ, img, label string, deviceSize, sectorSize quantity.Size) error {
+func mockMkfs(ctx context.Context, typ, img string, opts *mkfs.MakeOptions) error {
 	return fmt.Errorf("Test Error")
 }
 func mockReadDir(string) ([]os.DirEntry, error) {


### PR DESCRIPTION
Adapts callers of mkfs.Make and mkfs.MakeWithContent to the new unified API.

---

WIP until the snapd PR lands: https://github.com/canonical/snapd/pull/17186 