### PR TITLE
Fix missing explicit dependency on gpgv

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-image (3.10.10) UNRELEASED; urgency=medium
+
+  * Fix missing explicit dependency on gpgv
+
+ -- Oliver Reiche <oliver.reiche@canonical.com>  Wed, 02 Sep 2026 13:05:12 +0200
+
 ubuntu-image (3.10.9) UNRELEASED; urgency=medium
 
   [ Alexis Cellier ]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.10.9"
+version: "3.10.10"
 grade: stable
 confinement: classic
 base: core24

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -40,6 +40,7 @@ parts:
       - gdisk
       - fakeroot
       - debootstrap
+      - gpgv
       - gpg
       - germinate
       - git


### PR DESCRIPTION
... which is needed by debootstrap for some of its operations, but as it
is only declared in "Recommends", it is not installed automatically.

We recently noticed this issue on build hosts that switched to sequoia and
do not have gpgv installed locally.