### PR TITLE
go: update to account for instance name vs. snap name APIs in snapd

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-image (3.10.11) UNRELEASED; urgency=medium
+
+  * Update to account for instance name vs. snap name APIs in snapd
+
+ -- Andrew Phelps <andrew.phelps@canonical.com>  Fri, 11 Sep 2026 10:13:44 -0400
+
 ubuntu-image (3.10.10) UNRELEASED; urgency=medium
 
   [ Oliver Reiche ]

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 
 require (
 	github.com/snapcore/secboot v0.0.0-20260814094831-dd95d855ad64 // indirect
-	github.com/snapcore/snapd v0.0.0-20260901171049-fa2fe8db73ef
+	github.com/snapcore/snapd v0.0.0-20260911121130-33f12754e3af
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/snapcore/secboot v0.0.0-20260814094831-dd95d855ad64 h1:jZBwQI4+0/dypcKdQk9v5yi5pfKMVvXs/KG2XQlNjyI=
 github.com/snapcore/secboot v0.0.0-20260814094831-dd95d855ad64/go.mod h1:/J5bNHw8HkyxuUZRrk2LUzkne3zO/kEwJlm+/oB16SE=
-github.com/snapcore/snapd v0.0.0-20260901171049-fa2fe8db73ef h1:wnJ1VpgxblAOb+4u58VcqC0CNHYxe+7pXL21asrgIko=
-github.com/snapcore/snapd v0.0.0-20260901171049-fa2fe8db73ef/go.mod h1:S5g4xFl/g3criGb6Dtfj6W78nSEq0twblMwXKWuNmFg=
+github.com/snapcore/snapd v0.0.0-20260911121130-33f12754e3af h1:V9xy04hJIybunTbQ3hP7Hx+WpQcthecHG5Fh67pXs7g=
+github.com/snapcore/snapd v0.0.0-20260911121130-33f12754e3af/go.mod h1:S5g4xFl/g3criGb6Dtfj6W78nSEq0twblMwXKWuNmFg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/statemachine/helper.go
+++ b/internal/statemachine/helper.go
@@ -837,7 +837,7 @@ func getPreseededSnaps(rootfs string) (seededSnaps map[string]string, err error)
 
 	// iterate over the snaps in the seed and add them to the list
 	err = preseed.Iter(func(sn *seed.Snap) error {
-		seededSnaps[sn.SnapName()] = sn.Channel
+		seededSnaps[sn.SnapName().String()] = sn.Channel
 		return nil
 	})
 	if err != nil {

--- a/internal/statemachine/helper_test.go
+++ b/internal/statemachine/helper_test.go
@@ -1078,7 +1078,7 @@ func (f *mockSeed) ModeSnaps(mode string) ([]*seed.Snap, error) { return f.snaps
 
 func (f *mockSeed) ModeSnap(snapName, mode string) (*seed.Snap, error) {
 	for _, sn := range f.snaps {
-		if sn.SnapName() == snapName {
+		if sn.SnapName().String() == snapName {
 			return sn, nil
 		}
 	}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Create Ubuntu images
 description: |
   Official tool for building Ubuntu images, currently supporing Ubuntu Core
   snap-based images and preinstalled Ubuntu classic images.
-version: "3.10.10"
+version: "3.10.11"
 grade: stable
 confinement: classic
 base: core24


### PR DESCRIPTION
We tweaked some APIs in snapd to help us deal with instance names and snap names. This updates `ubuntu-image` to use the new API.